### PR TITLE
Fix editor to save note on vim modal changes,

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "gluesql",
  "home",
  "ratatui",
+ "throbber-widgets-tui",
  "tokio",
  "tui-big-text",
  "tui-textarea",
@@ -2315,6 +2316,16 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "throbber-widgets-tui"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d36b5738d666a2b4c91b7c24998a8588db724b3107258343ebf8824bf55b06d"
+dependencies = [
+ "rand",
+ "ratatui",
 ]
 
 [[package]]

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         data::{Directory, Note},
-        types::DirectoryId,
+        types::{DirectoryId, NoteId},
     },
     strum_macros::Display,
 };
@@ -64,7 +64,7 @@ pub enum NotebookEvent {
     EditNote,
     ViewNote,
 
-    UpdateNoteContent(String),
+    UpdateNoteContent { note_id: NoteId, content: String },
 
     CloseEntryDialog,
 }

--- a/core/src/state/notebook/consume/note.rs
+++ b/core/src/state/notebook/consume/note.rs
@@ -2,6 +2,7 @@ use crate::{
     data::{Directory, Note},
     db::Db,
     state::notebook::{DirectoryItem, InnerState, NotebookState, SelectedItem, VimNormalState},
+    types::NoteId,
     Error, NotebookTransition, Result,
 };
 
@@ -122,16 +123,15 @@ pub async fn view(state: &mut NotebookState) -> Result<NotebookTransition> {
 
 pub async fn update_content(
     db: &mut Db,
-    state: &mut NotebookState,
+    note_id: NoteId,
     content: String,
 ) -> Result<NotebookTransition> {
-    let id = state.get_editing()?.id.clone();
-    let current = db.fetch_note_content(id.clone()).await?;
+    let current = db.fetch_note_content(note_id.clone()).await?;
 
     if current == content {
         Ok(NotebookTransition::None)
     } else {
-        db.update_note_content(id, content).await?;
-        Ok(NotebookTransition::UpdateNoteContent)
+        db.update_note_content(note_id.clone(), content).await?;
+        Ok(NotebookTransition::UpdateNoteContent(note_id))
     }
 }

--- a/core/src/state/notebook/inner_state.rs
+++ b/core/src/state/notebook/inner_state.rs
@@ -7,7 +7,11 @@ mod note_more_actions;
 mod note_selected;
 mod note_tree_number;
 
-use crate::{db::Db, state::notebook::NotebookState, Event, NotebookTransition, Result};
+use crate::{
+    db::Db,
+    state::notebook::{note, NotebookState},
+    Event, NotebookEvent, NotebookTransition, Result,
+};
 pub use editing_normal_mode::VimNormalState;
 pub use editing_visual_mode::VimVisualState;
 
@@ -29,6 +33,10 @@ pub async fn consume(
     event: Event,
 ) -> Result<NotebookTransition> {
     use InnerState::*;
+
+    if let Event::Notebook(NotebookEvent::UpdateNoteContent { note_id, content }) = event {
+        return note::update_content(db, note_id, content).await;
+    }
 
     match &state.inner_state {
         NoteSelected => note_selected::consume(db, state, event).await,

--- a/core/src/state/notebook/inner_state/editing_normal_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode.rs
@@ -33,26 +33,22 @@ pub async fn consume(
     event: Event,
 ) -> Result<NotebookTransition> {
     match vim_state {
-        VimNormalState::Idle => consume_idle(db, state, event).await,
+        VimNormalState::Idle => consume_idle(state, event).await,
         VimNormalState::Toggle => consume_toggle(db, state, event).await,
-        VimNormalState::Numbering(n) => consume_numbering(db, state, n, event).await,
-        VimNormalState::Gateway => consume_gateway(db, state, event).await,
-        VimNormalState::Yank(n) => consume_yank(db, state, n, event).await,
-        VimNormalState::Yank2(n1, n2) => consume_yank2(db, state, n1, n2, event).await,
-        VimNormalState::Delete(n) => consume_delete(db, state, n, event).await,
-        VimNormalState::Delete2(n1, n2) => consume_delete2(db, state, n1, n2, event).await,
-        VimNormalState::DeleteInside(n) => consume_delete_inside(db, state, n, event).await,
-        VimNormalState::Change(n) => consume_change(db, state, n, event).await,
-        VimNormalState::Change2(n1, n2) => consume_change2(db, state, n1, n2, event).await,
-        VimNormalState::ChangeInside(n) => consume_change_inside(db, state, n, event).await,
+        VimNormalState::Numbering(n) => consume_numbering(state, n, event).await,
+        VimNormalState::Gateway => consume_gateway(state, event).await,
+        VimNormalState::Yank(n) => consume_yank(state, n, event).await,
+        VimNormalState::Yank2(n1, n2) => consume_yank2(state, n1, n2, event).await,
+        VimNormalState::Delete(n) => consume_delete(state, n, event).await,
+        VimNormalState::Delete2(n1, n2) => consume_delete2(state, n1, n2, event).await,
+        VimNormalState::DeleteInside(n) => consume_delete_inside(state, n, event).await,
+        VimNormalState::Change(n) => consume_change(state, n, event).await,
+        VimNormalState::Change2(n1, n2) => consume_change2(state, n1, n2, event).await,
+        VimNormalState::ChangeInside(n) => consume_change_inside(state, n, event).await,
     }
 }
 
-async fn consume_idle(
-    db: &mut Db,
-    state: &mut NotebookState,
-    event: Event,
-) -> Result<NotebookTransition> {
+async fn consume_idle(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
     use NotebookEvent as NE;
@@ -60,7 +56,6 @@ async fn consume_idle(
     match event {
         Notebook(NE::SelectNote(note)) => note::select(state, note),
         Notebook(NE::SelectDirectory(directory)) => directory::select(state, directory),
-        Notebook(NE::UpdateNoteContent(content)) => note::update_content(db, state, content).await,
         Key(KeyEvent::N) => {
             state.inner_state = InnerState::NoteSelected;
 
@@ -189,14 +184,13 @@ async fn consume_toggle(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_numbering(
-    db: &mut Db,
     state: &mut NotebookState,
     n: usize,
     event: Event,
@@ -292,17 +286,13 @@ async fn consume_numbering(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
-async fn consume_gateway(
-    db: &mut Db,
-    state: &mut NotebookState,
-    event: Event,
-) -> Result<NotebookTransition> {
+async fn consume_gateway(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -320,14 +310,13 @@ async fn consume_gateway(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_yank(
-    db: &mut Db,
     state: &mut NotebookState,
     n: usize,
     event: Event,
@@ -354,14 +343,13 @@ async fn consume_yank(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_yank2(
-    db: &mut Db,
     state: &mut NotebookState,
     n1: usize,
     n2: usize,
@@ -390,14 +378,13 @@ async fn consume_yank2(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_delete(
-    db: &mut Db,
     state: &mut NotebookState,
     n: usize,
     event: Event,
@@ -440,14 +427,13 @@ async fn consume_delete(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_delete2(
-    db: &mut Db,
     state: &mut NotebookState,
     n1: usize,
     n2: usize,
@@ -482,14 +468,13 @@ async fn consume_delete2(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_delete_inside(
-    db: &mut Db,
     state: &mut NotebookState,
     n: usize,
     event: Event,
@@ -506,14 +491,13 @@ async fn consume_delete_inside(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_change(
-    db: &mut Db,
     state: &mut NotebookState,
     n: usize,
     event: Event,
@@ -560,14 +544,13 @@ async fn consume_change(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_change2(
-    db: &mut Db,
     state: &mut NotebookState,
     n1: usize,
     n2: usize,
@@ -620,14 +603,13 @@ async fn consume_change2(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }
 }
 
 async fn consume_change_inside(
-    db: &mut Db,
     state: &mut NotebookState,
     n: usize,
     event: Event,
@@ -644,7 +626,7 @@ async fn consume_change_inside(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            consume_idle(db, state, event).await
+            consume_idle(state, event).await
         }
         _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
     }

--- a/core/src/transition.rs
+++ b/core/src/transition.rs
@@ -66,7 +66,7 @@ pub enum NotebookTransition {
 
     SelectNote(Note),
     SelectDirectory(Directory),
-    UpdateNoteContent,
+    UpdateNoteContent(NoteId),
 
     Alert(String),
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -19,3 +19,4 @@ tui-big-text = "0.7.0"
 tui-textarea = "0.7.0"
 home = "0.5.9"
 tokio = { version = "1.41.0", features = ["macros", "rt-multi-thread"] }
+throbber-widgets-tui = "0.8.0"

--- a/tui/src/context/notebook.rs
+++ b/tui/src/context/notebook.rs
@@ -83,6 +83,7 @@ pub struct NotebookContext {
 pub struct EditorTab {
     pub note: Note,
     pub editor: TextArea<'static>,
+    pub dirty: bool,
 }
 
 impl Default for NotebookContext {
@@ -126,6 +127,21 @@ impl NotebookContext {
             .and_then(|i| self.tabs.get_mut(i))
             .log_expect("no opened note")
             .editor
+    }
+
+    pub fn mark_dirty(&mut self) {
+        if let Some(tab) = self.tab_index.and_then(|i| self.tabs.get_mut(i)) {
+            tab.dirty = true;
+        }
+    }
+
+    pub fn mark_clean(&mut self, note_id: &NoteId) {
+        for tab in self.tabs.iter_mut() {
+            if &tab.note.id == note_id {
+                tab.dirty = false;
+                break;
+            }
+        }
     }
 
     pub fn close_tab(&mut self, note_id: &NoteId) {
@@ -198,6 +214,7 @@ impl NotebookContext {
             let tab = EditorTab {
                 note,
                 editor: TextArea::from(content.lines()),
+                dirty: false,
             };
             self.tabs.push(tab);
             self.tab_index = Some(self.tabs.len() - 1);

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -77,6 +77,7 @@ impl App {
                     self.handle_transition(transition).await;
                 }
 
+                self.save().await;
                 continue;
             }
 

--- a/tui/src/views/body/notebook/editor.rs
+++ b/tui/src/views/body/notebook/editor.rs
@@ -7,6 +7,7 @@ use {
         widgets::{Block, Padding},
         Frame,
     },
+    throbber_widgets_tui::Throbber,
     tui_textarea::TextArea,
 };
 
@@ -38,9 +39,20 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
     };
 
     let block = Block::bordered().title(title);
-    let block = match context.last_log.as_ref() {
-        Some((log, _)) => block.title_bottom(Line::from(log.clone().green()).right_aligned()),
-        None => block,
+    let block = match (
+        context.last_log.as_ref(),
+        context.notebook.tabs.iter().any(|tab| tab.dirty),
+    ) {
+        (_, true) => {
+            let throbber = Throbber::default()
+                .label("Saving...")
+                .style(Style::default().yellow());
+            block.title_bottom(Line::from(throbber).right_aligned())
+        }
+        (Some((log, _)), false) => {
+            block.title_bottom(Line::from(log.clone().green()).right_aligned())
+        }
+        (None, false) => block,
     }
     .padding(if context.notebook.show_line_number {
         Padding::ZERO


### PR DESCRIPTION
Update core notebook state root to handle UpdateNoteContent event, not only in vim normal mode inner state.
Add note id field to UpdateNoteContent event.
Update tui to dispatch UpdateNoteContent event after user stops editing and escape the insert mode.