### PR TITLE
Add Enter key binding to toggle directories in note browser

### DIFF
--- a/core/src/state/notebook/inner_state/directory_selected.rs
+++ b/core/src/state/notebook/inner_state/directory_selected.rs
@@ -14,7 +14,7 @@ pub async fn consume(
 
     match event {
         Notebook(OpenDirectory(directory_id)) => directory::open(db, state, directory_id).await,
-        Key(KeyEvent::L) | Key(KeyEvent::Right) => {
+        Key(KeyEvent::L | KeyEvent::Right | KeyEvent::Enter) => {
             let directory = state.get_selected_directory()?.clone();
             let directory_item = state.root.find(&directory.id).ok_or(Error::Wip(
                 "[Key::L] failed to find the target directory".to_owned(),


### PR DESCRIPTION
resolve #65 

## Description
Added Enter key binding to toggle (open/close) directories in the note browser. This makes the navigation more intuitive and consistent with note opening behavior.

## Changes
- Added Enter key support in directory_selected.rs to toggle directories
- Enter key now performs the same action as 'l' and right arrow keys:
  - Opens directory if it's closed
  - Closes directory if it's open

## Why
- Makes directory navigation more intuitive
- Provides consistent behavior with note opening where Enter key is also supported
- Follows common file 

## Testing
Verified that:
- Enter key opens closed directories
- Enter key closes opened directories
- Existing 'l' and right arrow key functionality remains unchanged