### PR TITLE
Fix [e] command description in vim keymap help

### DIFF
--- a/tui/src/views/dialog/vim_keymap.rs
+++ b/tui/src/views/dialog/vim_keymap.rs
@@ -38,7 +38,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[k] Move cursor up"),
                 Line::raw("[l] Move cursor right"),
                 Line::raw("[w] Move cursor to the start of the next word"),
-                Line::raw("[e] Move cursor to the end of the next word"),
+                Line::raw("[e] Move cursor to the end of the current word"),
                 Line::raw("[b] Move cursor to the start of the previous word"),
                 Line::raw("[0] Move cursor to the start of the line"),
                 Line::raw("[$] Move cursor to the end of the line"),


### PR DESCRIPTION
## Description
Updates the description of the [e] command in vim keymap help to be more accurate and consistent with vim's standard behavior.

## Changes
- Changed description from "Move cursor to the end of the next word" to "Move cursor to the end of the current word"

## Context
The previous description could be misleading as it emphasized "next" word, which might cause confusion with the [w] command. This change better reflects both vim's standard behavior and our actual implementation using `CursorMove::WordEnd`.

## Related Issue
fix #69 

## Screenshots

After:
<img width="690" alt="image" src="https://github.com/user-attachments/assets/1d66f272-510a-4ad1-b596-dd34d900545a">