### PR TITLE
Add tilde(~) switch case support to vim normal & visual modes

### DIFF
--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -109,6 +109,7 @@ pub enum KeyEvent {
     Down,
     Enter,
     Tab,
+    Tilde,
     Esc,
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode.rs
@@ -78,6 +78,7 @@ async fn consume_idle(state: &mut NotebookState, event: Event) -> Result<Noteboo
         Key(KeyEvent::B) => MoveCursorWordBack(1).into(),
         Key(KeyEvent::Num(NumKey::Zero)) => MoveCursorLineStart.into(),
         Key(KeyEvent::DollarSign) => MoveCursorLineEnd.into(),
+        Key(KeyEvent::Tilde) => SwitchCase.into(),
         Key(KeyEvent::Caret) => MoveCursorLineNonEmptyStart.into(),
         Key(KeyEvent::CapG) => MoveCursorBottom.into(),
         Key(KeyEvent::I) => {

--- a/core/src/state/notebook/inner_state/editing_visual_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode.rs
@@ -45,6 +45,11 @@ async fn consume_idle(
         Key(KeyEvent::DollarSign) => MoveCursorLineEnd.into(),
         Key(KeyEvent::Caret) => MoveCursorLineNonEmptyStart.into(),
         Key(KeyEvent::CapG) => MoveCursorBottom.into(),
+        Key(KeyEvent::Tilde) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            SwitchCase.into()
+        }
         Key(KeyEvent::D | KeyEvent::X) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 

--- a/core/src/transition.rs
+++ b/core/src/transition.rs
@@ -140,6 +140,7 @@ pub enum NormalModeTransition {
     Redo,
     YankLines(usize),
     DeleteInsideWord(usize),
+    SwitchCase,
 }
 
 #[derive(Display)]
@@ -163,6 +164,7 @@ pub enum VisualModeTransition {
     YankSelection,
     DeleteSelection,
     DeleteSelectionAndInsertMode,
+    SwitchCase,
 }
 
 impl From<EntryTransition> for Transition {

--- a/tui/src/action.rs
+++ b/tui/src/action.rs
@@ -425,6 +425,7 @@ fn to_event(input: Input) -> Option<KeyEvent> {
         KeyCode::Char('0') => NumKey::Zero.into(),
         KeyCode::Char('$') => KeyEvent::DollarSign,
         KeyCode::Char('^') => KeyEvent::Caret,
+        KeyCode::Char('~') => KeyEvent::Tilde,
         KeyCode::Left => KeyEvent::Left,
         KeyCode::Right => KeyEvent::Right,
         KeyCode::Up => KeyEvent::Up,

--- a/tui/src/transitions.rs
+++ b/tui/src/transitions.rs
@@ -477,6 +477,13 @@ impl App {
                 self.context.notebook.mark_dirty();
                 self.context.notebook.update_yank();
             }
+            SwitchCase => {
+                let editor = self.context.notebook.get_editor_mut();
+                editor.start_selection();
+                switch_case(editor);
+
+                self.context.notebook.mark_dirty();
+            }
         };
     }
 
@@ -593,6 +600,12 @@ impl App {
                 self.context.notebook.mark_dirty();
                 self.context.notebook.update_yank();
             }
+            SwitchCase => {
+                let editor = self.context.notebook.get_editor_mut();
+                switch_case(editor);
+
+                self.context.notebook.mark_dirty();
+            }
         }
     }
 
@@ -686,4 +699,25 @@ fn reselect_for_yank(editor: &mut TextArea) {
     editor.start_selection();
     editor.move_cursor(CursorMove::Jump(end.0 as u16, end.1 as u16));
     editor.move_cursor(CursorMove::Forward);
+}
+
+fn switch_case(editor: &mut TextArea) {
+    let yank = editor.yank_text();
+    reselect_for_yank(editor);
+    editor.cut();
+
+    let changed = editor
+        .yank_text()
+        .chars()
+        .map(|c| {
+            if c.is_uppercase() {
+                c.to_lowercase().to_string()
+            } else {
+                c.to_uppercase().to_string()
+            }
+        })
+        .collect::<String>();
+
+    editor.insert_str(changed);
+    editor.set_yank_text(yank);
 }

--- a/tui/src/views/dialog/vim_keymap.rs
+++ b/tui/src/views/dialog/vim_keymap.rs
@@ -46,6 +46,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[G] Move cursor to the end of the file"),
                 Line::raw(""),
                 Line::from("EDIT TEXT".white().on_dark_gray()),
+                Line::raw("[~] Toggle the case of the current character"),
                 Line::raw("[x] Delete character under the cursor"),
                 Line::raw("[u] Undo the last change"),
                 Line::raw("[Ctrl+r] Redo the last undone change"),
@@ -165,6 +166,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 "[x] Delete selected text".into(),
             ]),
             Line::raw("[y] Yank (copy) selected text"),
+            Line::raw("[~] Toggle the case of the select text"),
         ]),
         VimKeymapKind::VisualNumbering => ("VIM VISUAL MODE KEYMAP - NUMBERING", vec![
             Line::from("EXTENDING NUMBERING MODE".white().on_dark_gray()),


### PR DESCRIPTION
ref. #62 