### PR TITLE
Clarify add failure messages

### DIFF
--- a/core/src/state/notebook/consume/directory.rs
+++ b/core/src/state/notebook/consume/directory.rs
@@ -188,7 +188,10 @@ pub async fn add(
     let item = state
         .root
         .find_mut(&parent_id)
-        .ok_or(Error::Wip("todo: failed to find {parent_id}".to_owned()))?;
+        .ok_or(Error::Wip(format!(
+            "[directory::add] parent directory not found: {}",
+            parent_id
+        )))?;
 
     if let DirectoryItem {
         children: Some(children),

--- a/core/src/state/notebook/consume/directory.rs
+++ b/core/src/state/notebook/consume/directory.rs
@@ -185,13 +185,10 @@ pub async fn add(
     let parent_id = directory.id.clone();
     let directory = db.add_directory(parent_id.clone(), directory_name).await?;
 
-    let item = state
-        .root
-        .find_mut(&parent_id)
-        .ok_or(Error::Wip(format!(
-            "[directory::add] parent directory not found: {}",
-            parent_id
-        )))?;
+    let item = state.root.find_mut(&parent_id).ok_or(Error::Wip(format!(
+        "[directory::add] parent directory not found: {}",
+        parent_id
+    )))?;
 
     if let DirectoryItem {
         children: Some(children),

--- a/core/src/state/notebook/consume/note.rs
+++ b/core/src/state/notebook/consume/note.rs
@@ -93,7 +93,10 @@ pub async fn add(
     let item = state
         .root
         .find_mut(&directory.id)
-        .ok_or(Error::Wip("todo: failed to find".to_owned()))?;
+        .ok_or(Error::Wip(format!(
+            "[note::add] directory not found: {}",
+            directory.id
+        )))?;
 
     if let DirectoryItem {
         children: Some(children),


### PR DESCRIPTION
## Summary
- show directory ID when note creation fails
- show parent directory ID when directory creation fails

## Testing
- `cargo fmt` *(fails: could not download file)*
- `cargo check --workspace` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_e_68452001b0f0832aae9ab34080ec4324