### PR TITLE
Rename shortcuts method to keymap

### DIFF
--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -44,10 +44,10 @@ impl State {
         }
     }
 
-    pub fn shortcuts(&self) -> Vec<String> {
+    pub fn keymap(&self) -> Vec<String> {
         match &self.inner {
-            InnerState::EntryState(state) => state.shortcuts(),
-            InnerState::NotebookState(state) => state.shortcuts(),
+            InnerState::EntryState(state) => state.keymap(),
+            InnerState::NotebookState(state) => state.keymap(),
         }
     }
 }

--- a/core/src/state/entry.rs
+++ b/core/src/state/entry.rs
@@ -72,7 +72,7 @@ impl EntryState {
         )
     }
 
-    pub fn shortcuts(&self) -> Vec<String> {
+    pub fn keymap(&self) -> Vec<String> {
         vec![
             "[j]     Select next".to_owned(),
             "[k]     Select previous".to_owned(),

--- a/core/src/state/notebook.rs
+++ b/core/src/state/notebook.rs
@@ -259,10 +259,10 @@ impl NotebookState {
         })
     }
 
-    pub fn shortcuts(&self) -> Vec<String> {
+    pub fn keymap(&self) -> Vec<String> {
         match &self.inner_state {
             NoteTree(NoteTreeState::NoteSelected) => {
-                let mut shortcuts = vec![
+                let mut keymap = vec![
                     "[l]     Open note".to_owned(),
                     "[h]     Close parent directory".to_owned(),
                     "[j]     Select next".to_owned(),
@@ -279,14 +279,14 @@ impl NotebookState {
                 ];
 
                 if !self.tabs.is_empty() {
-                    shortcuts.push("[Tab]   Focus editor".to_owned());
+                    keymap.push("[Tab]   Focus editor".to_owned());
                 }
 
-                shortcuts.push("[Esc]   Quit".to_owned());
-                shortcuts
+                keymap.push("[Esc]   Quit".to_owned());
+                keymap
             }
             NoteTree(NoteTreeState::DirectorySelected) => {
-                let mut shortcuts = vec![
+                let mut keymap = vec![
                     "[l]     Toggle directory".to_owned(),
                     "[h]     Close parent directory".to_owned(),
                     "[j]     Select next".to_owned(),
@@ -302,11 +302,11 @@ impl NotebookState {
                 ];
 
                 if !self.tabs.is_empty() {
-                    shortcuts.push("[Tab]   Focus editor".to_owned());
+                    keymap.push("[Tab]   Focus editor".to_owned());
                 }
 
-                shortcuts.push("[Esc]   Quit".to_owned());
-                shortcuts
+                keymap.push("[Esc]   Quit".to_owned());
+                keymap
             }
             NoteTree(NoteTreeState::Numbering(n)) => {
                 vec![

--- a/tui/src/views/dialog.rs
+++ b/tui/src/views/dialog.rs
@@ -19,7 +19,7 @@ use {
 
 pub fn draw(frame: &mut Frame, state: &State, context: &mut Context) {
     if context.keymap {
-        keymap::draw(frame, state.shortcuts().as_slice());
+        keymap::draw(frame, state.keymap().as_slice());
     }
 
     if let Some(kind) = context.vim_keymap {


### PR DESCRIPTION
## Summary
- rename `shortcuts` method to `keymap`
- update call site in TUI dialog view

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6847b77c1330832abf1f4b5f6925da78