### PR TITLE
Fix shortcut keys for Git and MongoDB selection in entry menu

### DIFF
--- a/tui/src/context/entry.rs
+++ b/tui/src/context/entry.rs
@@ -87,8 +87,8 @@ impl EntryContext {
             }
             KeyCode::Char('1') => EntryEvent::OpenMemory.into(),
             KeyCode::Char('2') => open(LAST_FILE_PATH, TuiAction::OpenFile).await,
-            KeyCode::Char('3') => open_mongo().await,
-            KeyCode::Char('4') => open_git().await,
+            KeyCode::Char('3') => open_git().await,
+            KeyCode::Char('4') => open_mongo().await,
             KeyCode::Char('5') => open(LAST_CSV_PATH, TuiAction::OpenCsv).await,
             KeyCode::Char('6') => open(LAST_JSON_PATH, TuiAction::OpenJson).await,
             KeyCode::Char('a') => TuiAction::Help.into(),


### PR DESCRIPTION
## Summary
- adjust key mappings so `3` opens Git and `4` opens MongoDB

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_6847bd53afa4832a8b7a764d236774ae