### PR TITLE
Improve grammar in the path creation prompt

### DIFF
--- a/tui/src/context/entry.rs
+++ b/tui/src/context/entry.rs
@@ -40,7 +40,7 @@ impl EntryContext {
             TuiAction::Prompt {
                 message: vec![
                     Line::raw("Enter the path:"),
-                    Line::from("If path not exists, it will be created.".fg(GRAY_MEDIUM)),
+                    Line::from("If the path does not exist, it will be created.".fg(GRAY_MEDIUM)),
                 ],
                 action: Box::new(action.into()),
                 default: config::get(key).await,


### PR DESCRIPTION
## Summary
- fix grammar in prompt for entering a file path

## Testing
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_6847bd5b95a0832a976c1eaa704fe928