### PR TITLE
Add sunrise, midnight, and forest themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The built-in themes are:
 * `dark` – 256-color palette
 * `light` – 256-color palette
 * `pastel` – a light theme defined using RGB values
+* `sunrise` – a warm light theme defined using RGB values
+* `midnight` – a blue-toned dark theme defined using RGB values
+* `forest` – a nature-inspired dark theme defined using RGB values
 
 ## Roadmap
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -41,6 +41,9 @@ enum ThemeArg {
     Dark,
     Light,
     Pastel,
+    Sunrise,
+    Midnight,
+    Forest,
 }
 
 #[tokio::main]
@@ -51,6 +54,9 @@ async fn main() -> Result<()> {
         ThemeArg::Dark => theme::set_theme(theme::DARK_THEME),
         ThemeArg::Light => theme::set_theme(theme::LIGHT_THEME),
         ThemeArg::Pastel => theme::set_theme(theme::PASTEL_THEME),
+        ThemeArg::Sunrise => theme::set_theme(theme::SUNRISE_THEME),
+        ThemeArg::Midnight => theme::set_theme(theme::MIDNIGHT_THEME),
+        ThemeArg::Forest => theme::set_theme(theme::FOREST_THEME),
     }
 
     config::init().await;

--- a/tui/src/theme/forest.rs
+++ b/tui/src/theme/forest.rs
@@ -1,0 +1,26 @@
+use super::Theme;
+use ratatui::style::Color;
+
+pub const FOREST_THEME: Theme = Theme {
+    background: Color::Rgb(15, 20, 15),
+    surface: Color::Rgb(25, 30, 25),
+    panel: Color::Rgb(40, 50, 40),
+    text: Color::Rgb(220, 220, 215),
+    text_secondary: Color::Rgb(160, 160, 155),
+    hint: Color::Rgb(120, 130, 120),
+    menu: Color::Rgb(140, 150, 140),
+    accent: Color::Rgb(70, 160, 70),
+    accent_text: Color::Rgb(0, 0, 0),
+    highlight: Color::Rgb(100, 200, 100),
+    target: Color::Rgb(200, 160, 70),
+    warning: Color::Rgb(255, 180, 20),
+    warning_text: Color::Rgb(32, 32, 32),
+    success: Color::Rgb(100, 220, 120),
+    success_text: Color::Rgb(0, 0, 0),
+    error: Color::Rgb(200, 70, 50),
+    error_text: Color::Rgb(0, 0, 0),
+    inactive_text: Color::Rgb(100, 110, 100),
+    inactive_bg: Color::Rgb(50, 60, 50),
+    crumb_a: Color::Rgb(30, 40, 30),
+    crumb_b: Color::Rgb(45, 55, 45),
+};

--- a/tui/src/theme/midnight.rs
+++ b/tui/src/theme/midnight.rs
@@ -1,0 +1,26 @@
+use super::Theme;
+use ratatui::style::Color;
+
+pub const MIDNIGHT_THEME: Theme = Theme {
+    background: Color::Rgb(10, 10, 20),
+    surface: Color::Rgb(20, 20, 40),
+    panel: Color::Rgb(40, 40, 60),
+    text: Color::Rgb(220, 220, 230),
+    text_secondary: Color::Rgb(150, 150, 170),
+    hint: Color::Rgb(120, 120, 140),
+    menu: Color::Rgb(100, 100, 120),
+    accent: Color::Rgb(50, 150, 250),
+    accent_text: Color::Rgb(0, 0, 0),
+    highlight: Color::Rgb(70, 170, 255),
+    target: Color::Rgb(200, 60, 250),
+    warning: Color::Rgb(255, 190, 0),
+    warning_text: Color::Rgb(0, 0, 0),
+    success: Color::Rgb(40, 200, 40),
+    success_text: Color::Rgb(0, 0, 0),
+    error: Color::Rgb(240, 60, 60),
+    error_text: Color::Rgb(0, 0, 0),
+    inactive_text: Color::Rgb(90, 90, 110),
+    inactive_bg: Color::Rgb(30, 30, 50),
+    crumb_a: Color::Rgb(35, 35, 55),
+    crumb_b: Color::Rgb(55, 55, 75),
+};

--- a/tui/src/theme/mod.rs
+++ b/tui/src/theme/mod.rs
@@ -2,10 +2,16 @@ use once_cell::sync::OnceCell;
 use ratatui::style::Color;
 
 pub mod dark;
+pub mod forest;
 pub mod light;
+pub mod midnight;
 pub mod pastel;
+pub mod sunrise;
 
-pub use {dark::DARK_THEME, light::LIGHT_THEME, pastel::PASTEL_THEME};
+pub use {
+    dark::DARK_THEME, forest::FOREST_THEME, light::LIGHT_THEME, midnight::MIDNIGHT_THEME,
+    pastel::PASTEL_THEME, sunrise::SUNRISE_THEME,
+};
 
 #[derive(Clone, Copy, Debug)]
 #[allow(dead_code)]

--- a/tui/src/theme/sunrise.rs
+++ b/tui/src/theme/sunrise.rs
@@ -1,0 +1,26 @@
+use super::Theme;
+use ratatui::style::Color;
+
+pub const SUNRISE_THEME: Theme = Theme {
+    background: Color::Rgb(255, 249, 240),
+    surface: Color::Rgb(255, 255, 254),
+    panel: Color::Rgb(255, 235, 205),
+    text: Color::Rgb(32, 32, 32),
+    text_secondary: Color::Rgb(80, 70, 60),
+    hint: Color::Rgb(128, 120, 100),
+    menu: Color::Rgb(70, 60, 50),
+    accent: Color::Rgb(255, 102, 0),
+    accent_text: Color::Rgb(255, 255, 255),
+    highlight: Color::Rgb(255, 140, 50),
+    target: Color::Rgb(200, 90, 180),
+    warning: Color::Rgb(255, 200, 0),
+    warning_text: Color::Rgb(32, 32, 32),
+    success: Color::Rgb(60, 175, 75),
+    success_text: Color::Rgb(255, 255, 255),
+    error: Color::Rgb(210, 50, 40),
+    error_text: Color::Rgb(255, 255, 255),
+    inactive_text: Color::Rgb(120, 120, 120),
+    inactive_bg: Color::Rgb(240, 220, 200),
+    crumb_a: Color::Rgb(250, 240, 230),
+    crumb_b: Color::Rgb(240, 220, 210),
+};


### PR DESCRIPTION
## Summary
- add new RGB color schemes: Sunrise, Midnight and Forest
- export the new themes in `theme::mod`
- expose the new themes on the CLI and mention in the README

## Testing
- `cargo fmt`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68490d5f71a4832ab432c84f326030ba