### PR TITLE
Introduce keymap grouping

### DIFF
--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -3,7 +3,7 @@ pub mod notebook;
 
 use crate::{
     Error, Event, Glues, KeyEvent, Result, Transition, transition::KeymapTransition,
-    types::KeymapItem,
+    types::KeymapGroup,
 };
 
 pub use {entry::EntryState, notebook::NotebookState};
@@ -47,7 +47,7 @@ impl State {
         }
     }
 
-    pub fn keymap(&self) -> Vec<KeymapItem> {
+    pub fn keymap(&self) -> Vec<KeymapGroup> {
         match &self.inner {
             InnerState::EntryState(state) => state.keymap(),
             InnerState::NotebookState(state) => state.keymap(),

--- a/core/src/state/entry.rs
+++ b/core/src/state/entry.rs
@@ -1,6 +1,8 @@
 use crate::{
-    EntryEvent, EntryTransition, Error, Event, Glues, Result, db::Db,
-    state::notebook::NotebookState, types::KeymapItem,
+    EntryEvent, EntryTransition, Error, Event, Glues, Result,
+    db::Db,
+    state::notebook::NotebookState,
+    types::{KeymapGroup, KeymapItem},
 };
 
 pub struct EntryState;
@@ -72,12 +74,15 @@ impl EntryState {
         )
     }
 
-    pub fn keymap(&self) -> Vec<KeymapItem> {
-        vec![
-            KeymapItem::new("j", "Select next"),
-            KeymapItem::new("k", "Select previous"),
-            KeymapItem::new("Enter", "Run selected item"),
-            KeymapItem::new("q", "Quit"),
-        ]
+    pub fn keymap(&self) -> Vec<KeymapGroup> {
+        vec![KeymapGroup::new(
+            "General",
+            vec![
+                KeymapItem::new("j", "Select next"),
+                KeymapItem::new("k", "Select previous"),
+                KeymapItem::new("Enter", "Run selected item"),
+                KeymapItem::new("q", "Quit"),
+            ],
+        )]
     }
 }

--- a/core/src/state/notebook.rs
+++ b/core/src/state/notebook.rs
@@ -7,7 +7,7 @@ use {
         Error, Event, Glues, NotebookTransition, Result,
         data::{Directory, Note},
         state::GetInner,
-        types::{DirectoryId, Id, KeymapItem},
+        types::{DirectoryId, Id, KeymapGroup, KeymapItem},
     },
     consume::{directory, note, tabs},
 };
@@ -259,7 +259,7 @@ impl NotebookState {
         })
     }
 
-    pub fn keymap(&self) -> Vec<KeymapItem> {
+    pub fn keymap(&self) -> Vec<KeymapGroup> {
         match &self.inner_state {
             NoteTree(NoteTreeState::NoteSelected) => {
                 let mut keymap = vec![
@@ -283,7 +283,7 @@ impl NotebookState {
                 }
 
                 keymap.push(KeymapItem::new("Esc", "Quit"));
-                keymap
+                vec![KeymapGroup::new("General", keymap)]
             }
             NoteTree(NoteTreeState::DirectorySelected) => {
                 let mut keymap = vec![
@@ -306,10 +306,10 @@ impl NotebookState {
                 }
 
                 keymap.push(KeymapItem::new("Esc", "Quit"));
-                keymap
+                vec![KeymapGroup::new("General", keymap)]
             }
             NoteTree(NoteTreeState::Numbering(n)) => {
-                vec![
+                let items = vec![
                     KeymapItem::new("j", format!("Select {n} next")),
                     KeymapItem::new("k", format!("Select {n} previous")),
                     KeymapItem::new("G", "Select last"),
@@ -317,29 +317,36 @@ impl NotebookState {
                     KeymapItem::new(">", format!("Expand width by {n}")),
                     KeymapItem::new("<", format!("Shrink width by {n}")),
                     KeymapItem::new("Esc", "Cancel"),
-                ]
+                ];
+                vec![KeymapGroup::new("General", items)]
             }
             NoteTree(NoteTreeState::GatewayMode) => {
-                vec![
-                    KeymapItem::new("g", "Select first"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("g", "Select first"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             NoteTree(NoteTreeState::MoveMode) => {
-                vec![
-                    KeymapItem::new("j", "Select next"),
-                    KeymapItem::new("k", "Select previous"),
-                    KeymapItem::new("G", "Select last"),
-                    KeymapItem::new("Enter", "Move to selected directory"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("j", "Select next"),
+                        KeymapItem::new("k", "Select previous"),
+                        KeymapItem::new("G", "Select last"),
+                        KeymapItem::new("Enter", "Move to selected directory"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Idle) => {
                 /*
                     h j k l w e b [1-9] o O 0 $
                     a, A, I, G, g, s, S, x, ^, y, d, u, Ctrl+r
                 */
-                vec![
+                let items = vec![
                     KeymapItem::new("Tab", "Browse notes"),
                     KeymapItem::new("t", "Enter toggle-tabs mode"),
                     KeymapItem::new("i", "Enter insert mode"),
@@ -347,31 +354,38 @@ impl NotebookState {
                     KeymapItem::new("z", "Enter scroll mode"),
                     KeymapItem::new("Ctrl+h", "Show Vim keymap"),
                     KeymapItem::new("Esc", "Quit"),
-                ]
+                ];
+                vec![KeymapGroup::new("General", items)]
             }
             EditingNormalMode(VimNormalState::Toggle) => {
-                vec![
-                    KeymapItem::new("h", "select left tab"),
-                    KeymapItem::new("l", "select right tab"),
-                    KeymapItem::new("H", "Move current tab to left"),
-                    KeymapItem::new("L", "Move current tab to right"),
-                    KeymapItem::new("x", "Close current tab"),
-                    KeymapItem::new("X", "Enter tab close mode"),
-                    KeymapItem::new("b", "Toggle browser"),
-                    KeymapItem::new("n", "Toggle editor line number"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("h", "select left tab"),
+                        KeymapItem::new("l", "select right tab"),
+                        KeymapItem::new("H", "Move current tab to left"),
+                        KeymapItem::new("L", "Move current tab to right"),
+                        KeymapItem::new("x", "Close current tab"),
+                        KeymapItem::new("X", "Enter tab close mode"),
+                        KeymapItem::new("b", "Toggle browser"),
+                        KeymapItem::new("n", "Toggle editor line number"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::ToggleTabClose) => {
-                vec![
-                    KeymapItem::new("h", "Close left tabs"),
-                    KeymapItem::new("l", "Close right tabs"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("h", "Close left tabs"),
+                        KeymapItem::new("l", "Close right tabs"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Numbering(n)) => {
                 // h j k l [0-9] s S x y d w e b G
-                vec![
+                let items = vec![
                     KeymapItem::new("j", format!("Move cursor {n} steps down")),
                     KeymapItem::new("k", format!("Move cursor {n} steps up")),
                     KeymapItem::new("h", format!("Move cursor {n} steps left")),
@@ -379,124 +393,155 @@ impl NotebookState {
                     KeymapItem::new("0-9", "Append steps"),
                     KeymapItem::new("Ctrl+h", "Show Vim keymap"),
                     KeymapItem::new("Esc", "Cancel"),
-                ]
+                ];
+                vec![KeymapGroup::new("General", items)]
             }
             EditingNormalMode(VimNormalState::Gateway) => {
-                vec![
-                    KeymapItem::new("g", "Move cursor to top"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("g", "Move cursor to top"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Yank(n)) => {
-                vec![
-                    KeymapItem::new("y", format!("Yank {n} lines")),
-                    KeymapItem::new("1-9", "Append steps"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("y", format!("Yank {n} lines")),
+                        KeymapItem::new("1-9", "Append steps"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Yank2(n1, n2)) => {
-                vec![
-                    if *n1 == 1 {
-                        KeymapItem::new("y", format!("Yank {n2} lines"))
-                    } else {
-                        KeymapItem::new("y", format!("Yank {n1}*{n2} lines"))
-                    },
-                    KeymapItem::new("0-9", "Append steps"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        if *n1 == 1 {
+                            KeymapItem::new("y", format!("Yank {n2} lines"))
+                        } else {
+                            KeymapItem::new("y", format!("Yank {n1}*{n2} lines"))
+                        },
+                        KeymapItem::new("0-9", "Append steps"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Delete(n)) => {
-                vec![
-                    KeymapItem::new("i", "Enter delete inside mode"),
-                    KeymapItem::new("d", format!("Delete {n} lines")),
-                    KeymapItem::new("0", "Delete from start of line"),
-                    KeymapItem::new("b", "Delete previous word"),
-                    KeymapItem::new("e", "Delete to word end"),
-                    KeymapItem::new("h", "Delete previous character"),
-                    KeymapItem::new("l", "Delete next character"),
-                    KeymapItem::new("$", "Delete to line end"),
-                    KeymapItem::new("1-9", "Append steps"),
-                    KeymapItem::new("Ctrl+h", "Show Vim keymap"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("i", "Enter delete inside mode"),
+                        KeymapItem::new("d", format!("Delete {n} lines")),
+                        KeymapItem::new("0", "Delete from start of line"),
+                        KeymapItem::new("b", "Delete previous word"),
+                        KeymapItem::new("e", "Delete to word end"),
+                        KeymapItem::new("h", "Delete previous character"),
+                        KeymapItem::new("l", "Delete next character"),
+                        KeymapItem::new("$", "Delete to line end"),
+                        KeymapItem::new("1-9", "Append steps"),
+                        KeymapItem::new("Ctrl+h", "Show Vim keymap"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Delete2(n1, n2)) => {
-                vec![
-                    if *n1 == 1 {
-                        KeymapItem::new("d", format!("Delete {n2} lines"))
-                    } else {
-                        KeymapItem::new("d", format!("Delete {n1}*{n2} lines"))
-                    },
-                    KeymapItem::new("i", "Enter delete inside mode"),
-                    KeymapItem::new("b", "Delete previous word"),
-                    KeymapItem::new("e", "Delete to word end"),
-                    KeymapItem::new("h", "Delete previous character"),
-                    KeymapItem::new("l", "Delete next character"),
-                    KeymapItem::new("$", "Delete to line end"),
-                    KeymapItem::new("0-9", "Append steps"),
-                    KeymapItem::new("Ctrl+h", "Show Vim keymap"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        if *n1 == 1 {
+                            KeymapItem::new("d", format!("Delete {n2} lines"))
+                        } else {
+                            KeymapItem::new("d", format!("Delete {n1}*{n2} lines"))
+                        },
+                        KeymapItem::new("i", "Enter delete inside mode"),
+                        KeymapItem::new("b", "Delete previous word"),
+                        KeymapItem::new("e", "Delete to word end"),
+                        KeymapItem::new("h", "Delete previous character"),
+                        KeymapItem::new("l", "Delete next character"),
+                        KeymapItem::new("$", "Delete to line end"),
+                        KeymapItem::new("0-9", "Append steps"),
+                        KeymapItem::new("Ctrl+h", "Show Vim keymap"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::DeleteInside(n)) => {
-                vec![
-                    if *n == 1 {
-                        KeymapItem::new("w", "Delete the current word")
-                    } else {
-                        KeymapItem::new("w", format!("Delete {n} words from cursor"))
-                    },
-                    KeymapItem::new("Ctrl+h", "Show Vim keymap"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        if *n == 1 {
+                            KeymapItem::new("w", "Delete the current word")
+                        } else {
+                            KeymapItem::new("w", format!("Delete {n} words from cursor"))
+                        },
+                        KeymapItem::new("Ctrl+h", "Show Vim keymap"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Change(n)) => {
-                vec![
-                    KeymapItem::new("i", "Enter change inside mode"),
-                    KeymapItem::new("c", format!("Delete {n} lines and enter insert mode")),
-                    KeymapItem::new("Ctrl+h", "Show Vim keymap"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("i", "Enter change inside mode"),
+                        KeymapItem::new("c", format!("Delete {n} lines and enter insert mode")),
+                        KeymapItem::new("Ctrl+h", "Show Vim keymap"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Change2(n1, n2)) => {
-                vec![
-                    if *n1 == 1 {
-                        KeymapItem::new("c", format!("Delete {n2} lines and enter insert mode"))
-                    } else {
-                        KeymapItem::new(
-                            "c",
-                            format!("Delete {n1}*{n2} lines and enter insert mode"),
-                        )
-                    },
-                    KeymapItem::new("i", "Enter change inside mode"),
-                    KeymapItem::new("0-9", "Append steps"),
-                    KeymapItem::new("Ctrl+h", "Show Vim keymap"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        if *n1 == 1 {
+                            KeymapItem::new("c", format!("Delete {n2} lines and enter insert mode"))
+                        } else {
+                            KeymapItem::new(
+                                "c",
+                                format!("Delete {n1}*{n2} lines and enter insert mode"),
+                            )
+                        },
+                        KeymapItem::new("i", "Enter change inside mode"),
+                        KeymapItem::new("0-9", "Append steps"),
+                        KeymapItem::new("Ctrl+h", "Show Vim keymap"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::ChangeInside(n)) => {
-                vec![
-                    if *n == 1 {
-                        KeymapItem::new("w", "Delete the current word and enter insert mode")
-                    } else {
-                        KeymapItem::new(
-                            "w",
-                            format!("Delete {n} words from cursor and enter insert mode"),
-                        )
-                    },
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        if *n == 1 {
+                            KeymapItem::new("w", "Delete the current word and enter insert mode")
+                        } else {
+                            KeymapItem::new(
+                                "w",
+                                format!("Delete {n} words from cursor and enter insert mode"),
+                            )
+                        },
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingNormalMode(VimNormalState::Scroll) => {
-                vec![
-                    KeymapItem::new("z|.", "Scroll to center"),
-                    KeymapItem::new("t|Enter", "Scroll to top"),
-                    KeymapItem::new("b|-", "Scroll to bottom"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("z|.", "Scroll to center"),
+                        KeymapItem::new("t|Enter", "Scroll to top"),
+                        KeymapItem::new("b|-", "Scroll to bottom"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingVisualMode(VimVisualState::Idle) => {
                 // more in the keymap
-                vec![
+                let items = vec![
                     KeymapItem::new("j", "Move cursor down"),
                     KeymapItem::new("k", "Move cursor up"),
                     KeymapItem::new("h", "Move cursor left"),
@@ -504,11 +549,12 @@ impl NotebookState {
                     KeymapItem::new("1-9", "Append steps"),
                     KeymapItem::new("Ctrl+h", "Show Vim keymap"),
                     KeymapItem::new("Esc", "Cancel"),
-                ]
+                ];
+                vec![KeymapGroup::new("General", items)]
             }
             EditingVisualMode(VimVisualState::Numbering(n)) => {
                 // more in the keymap
-                vec![
+                let items = vec![
                     KeymapItem::new("j", format!("Move cursor {n} steps down")),
                     KeymapItem::new("k", format!("Move cursor {n} steps up")),
                     KeymapItem::new("h", format!("Move cursor {n} steps left")),
@@ -516,27 +562,37 @@ impl NotebookState {
                     KeymapItem::new("0-9", "Append steps"),
                     KeymapItem::new("Ctrl+h", "Show Vim keymap"),
                     KeymapItem::new("Esc", "Cancel"),
-                ]
+                ];
+                vec![KeymapGroup::new("General", items)]
             }
             EditingVisualMode(VimVisualState::Gateway) => {
-                vec![
-                    KeymapItem::new("g", "Move cursor to top"),
-                    KeymapItem::new("Esc", "Cancel"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("g", "Move cursor to top"),
+                        KeymapItem::new("Esc", "Cancel"),
+                    ],
+                )]
             }
             EditingInsertMode => {
-                vec![
-                    KeymapItem::new("Esc", "Save note and enter normal mode"),
-                    KeymapItem::new("Ctrl+h", "Show editor keymap"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("Esc", "Save note and enter normal mode"),
+                        KeymapItem::new("Ctrl+h", "Show editor keymap"),
+                    ],
+                )]
             }
             NoteTree(NoteTreeState::DirectoryMoreActions | NoteTreeState::NoteMoreActions) => {
-                vec![
-                    KeymapItem::new("j", "Select next"),
-                    KeymapItem::new("k", "Select Previous"),
-                    KeymapItem::new("Enter", "Run selected item"),
-                    KeymapItem::new("Esc", "Close"),
-                ]
+                vec![KeymapGroup::new(
+                    "General",
+                    vec![
+                        KeymapItem::new("j", "Select next"),
+                        KeymapItem::new("k", "Select Previous"),
+                        KeymapItem::new("Enter", "Run selected item"),
+                        KeymapItem::new("Esc", "Close"),
+                    ],
+                )]
             }
         }
     }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -16,3 +16,18 @@ impl KeymapItem {
         }
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct KeymapGroup {
+    pub title: String,
+    pub items: Vec<KeymapItem>,
+}
+
+impl KeymapGroup {
+    pub fn new<T: Into<String>>(title: T, items: Vec<KeymapItem>) -> Self {
+        Self {
+            title: title.into(),
+            items,
+        }
+    }
+}

--- a/tui/src/views/dialog/keymap.rs
+++ b/tui/src/views/dialog/keymap.rs
@@ -1,6 +1,6 @@
 use {
     crate::theme::THEME,
-    glues_core::types::KeymapItem,
+    glues_core::types::{KeymapGroup, KeymapItem},
     ratatui::{
         Frame,
         layout::{
@@ -18,7 +18,7 @@ use {
 const KEYMAP_WIDTH: u16 = 46;
 const KEY_WIDTH: u16 = 10;
 
-pub fn draw(frame: &mut Frame, keymap: &[KeymapItem]) {
+pub fn draw(frame: &mut Frame, keymap: &[KeymapGroup]) {
     let [area] = Layout::horizontal([Length(KEYMAP_WIDTH)])
         .flex(Flex::End)
         .areas(frame.area());
@@ -43,32 +43,60 @@ pub fn draw(frame: &mut Frame, keymap: &[KeymapItem]) {
     let inner_area = block.inner(area);
     let desc_width = inner_area.width.saturating_sub(KEY_WIDTH + 1);
 
-    let heights: Vec<u16> = keymap
+    enum Row<'a> {
+        Title(&'a str),
+        Item(&'a KeymapItem),
+    }
+
+    let mut rows = Vec::new();
+    for group in keymap {
+        rows.push(Row::Title(&group.title));
+        for item in &group.items {
+            rows.push(Row::Item(item));
+        }
+    }
+
+    let heights: Vec<u16> = rows
         .iter()
-        .map(|item| wrap(&item.desc, desc_width as usize).len() as u16)
+        .map(|row| match row {
+            Row::Title(_) => 1,
+            Row::Item(item) => wrap(&item.desc, desc_width as usize).len() as u16,
+        })
         .collect();
 
     let row_constraints = heights.iter().map(|h| Length(*h)).collect::<Vec<_>>();
-    let rows = Layout::vertical(row_constraints).split(inner_area);
+    let row_areas = Layout::vertical(row_constraints).split(inner_area);
 
     frame.render_widget(Clear, area);
     frame.render_widget(block.clone(), area);
 
-    for (row_area, item) in rows.iter().zip(keymap) {
-        let [key_area, desc_area] =
-            Layout::horizontal([Length(KEY_WIDTH), Length(desc_width)]).areas(*row_area);
+    for (row_area, row) in row_areas.into_iter().zip(rows) {
+        match row {
+            Row::Title(title) => {
+                let line = Line::from(title.to_string())
+                    .fg(THEME.warning_text)
+                    .bg(THEME.warning);
+                let paragraph = Paragraph::new(line).alignment(Alignment::Left);
+                frame.render_widget(paragraph, *row_area);
+            }
+            Row::Item(item) => {
+                let [key_area, desc_area] =
+                    Layout::horizontal([Length(KEY_WIDTH), Length(desc_width)]).areas(*row_area);
 
-        let key_paragraph = Paragraph::new(Line::from(vec![Span::raw(format!("[{}]", item.key))]))
-            .alignment(Alignment::Left);
-        let desc_lines: Vec<Line> = wrap(&item.desc, desc_width as usize)
-            .into_iter()
-            .map(|c| Line::from(c.into_owned()))
-            .collect();
-        let desc_paragraph = Paragraph::new(desc_lines)
-            .alignment(Alignment::Left)
-            .style(Style::default());
+                let key_paragraph =
+                    Paragraph::new(Line::from(vec![Span::raw(format!("[{}]", item.key))]))
+                        .alignment(Alignment::Left);
+                let desc_lines: Vec<Line> = wrap(&item.desc, desc_width as usize)
+                    .into_iter()
+                    .map(|c| Line::from(c.into_owned()))
+                    .collect();
+                let desc_paragraph = Paragraph::new(desc_lines)
+                    .alignment(Alignment::Left)
+                    .style(Style::default());
 
-        frame.render_widget(key_paragraph, key_area);
-        frame.render_widget(desc_paragraph, desc_area);
+                frame.render_widget(key_paragraph, key_area);
+                frame.render_widget(desc_paragraph, desc_area);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support grouping `KeymapItem`s into `KeymapGroup`
- display keymap groups in popup dialog
- adapt state implementations to return grouped keymaps

## Testing
- `cargo fmt`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684928d83568832a8afe252e817e3f55