### PR TITLE
Add proxy client/server layer to core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -170,8 +170,14 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -205,6 +211,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigdecimal"
@@ -294,7 +306,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
  "syn_derive",
 ]
 
@@ -362,9 +374,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cassowary"
@@ -448,7 +460,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -544,7 +556,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -678,7 +690,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -700,7 +712,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -747,7 +759,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -757,7 +769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -770,7 +782,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -792,7 +804,7 @@ checksum = "61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -811,6 +823,15 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -857,6 +878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,12 +925,21 @@ checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -914,8 +950,14 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1006,7 +1048,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1105,8 +1147,10 @@ dependencies = [
  "async-trait",
  "gluesql",
  "gluesql-mongo-storage",
+ "reqwest",
+ "serde",
  "strum_macros 0.26.4",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "uuid",
 ]
@@ -1152,7 +1196,7 @@ dependencies = [
  "serde_json",
  "sqlparser",
  "strum_macros 0.25.3",
- "thiserror",
+ "thiserror 1.0.61",
  "uuid",
 ]
 
@@ -1169,7 +1213,7 @@ dependencies = [
  "gluesql-utils",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1215,7 +1259,7 @@ dependencies = [
  "iter-enum",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
 ]
 
@@ -1236,7 +1280,7 @@ dependencies = [
  "serde_json",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1260,6 +1304,25 @@ dependencies = [
  "futures",
  "gluesql-core",
  "serde",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1332,6 +1395,118 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi",
+]
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1450,7 +1625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
 dependencies = [
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1518,10 +1693,11 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1618,6 +1794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,8 +1856,8 @@ dependencies = [
  "percent-encoding",
  "rand",
  "rustc_version_runtime",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -1685,15 +1867,32 @@ dependencies = [
  "stringprep",
  "strsim 0.10.0",
  "take_mut",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "trust-dns-proto",
  "trust-dns-resolver",
  "typed-builder",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1851,6 +2050,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-float"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,7 +2171,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1942,6 +2185,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
@@ -2002,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2034,6 +2283,57 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.27",
+ "socket2 0.5.7",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -2160,6 +2460,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.27",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls 0.26.2",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.11",
+ "windows-registry",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2597,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,8 +2651,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2310,12 +2679,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2330,6 +2729,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2352,6 +2760,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2400,7 +2831,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2410,6 +2841,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -2645,7 +3088,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2658,7 +3101,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2680,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.49"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2698,7 +3141,37 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2712,6 +3185,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "textwrap"
@@ -2730,7 +3216,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2741,7 +3236,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2836,7 +3342,17 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2845,7 +3361,17 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls 0.23.27",
  "tokio",
 ]
 
@@ -2888,6 +3414,33 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2949,7 +3502,7 @@ dependencies = [
  "log",
  "rand",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.61",
  "tinyvec",
  "tokio",
  "url",
@@ -2970,10 +3523,16 @@ dependencies = [
  "parking_lot",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "trust-dns-proto",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-big-text"
@@ -3118,10 +3677,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -3131,34 +3705,48 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.92"
+name = "wasm-bindgen-futures"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3166,28 +3754,69 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "weezl"
@@ -3230,6 +3859,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3283,11 +3947,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3303,6 +3983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3999,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3327,10 +4019,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3345,6 +4049,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,6 +4065,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3369,6 +4085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3379,6 +4101,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -3442,5 +4170,11 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.102",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +190,61 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -428,6 +489,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -1145,12 +1212,15 @@ version = "0.6.3"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "axum",
  "gluesql",
  "gluesql-mongo-storage",
  "reqwest",
  "serde",
+ "serde_json",
  "strum_macros 0.26.4",
  "thiserror 1.0.61",
+ "tiny_http",
  "tokio",
  "uuid",
 ]
@@ -1438,6 +1508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1526,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1776,6 +1853,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -2847,6 +2930,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +3396,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3533,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3448,6 +3554,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,3 +21,6 @@ tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["macros", "rt"] }
+axum = "0.7"
+tiny_http = "0.12"
+serde_json = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,9 @@ thiserror = "1.0.61"
 async-trait = "0.1"
 uuid = { version = "1.10", features = ["v7"] }
 strum_macros = "0.26.4"
+serde = { version = "1.0", features = ["derive"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["macros", "rt"] }

--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -1,13 +1,14 @@
 use crate::types::{DirectoryId, NoteId};
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Note {
     pub id: NoteId,
     pub directory_id: DirectoryId,
     pub name: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Directory {
     pub id: DirectoryId,
     pub parent_id: DirectoryId,

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -5,6 +5,9 @@ pub enum Error {
     #[error("gluesql: {0}")]
     GlueSql(#[from] gluesql::prelude::Error),
 
+    #[error("reqwest: {0}")]
+    Reqwest(#[from] reqwest::Error),
+
     #[error("wip: {0}")]
     Wip(String),
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,10 +6,10 @@ mod schema;
 mod task;
 
 pub mod data;
+pub mod proxy;
 pub mod state;
 pub mod transition;
 pub mod types;
-pub mod proxy;
 
 pub use error::Error;
 pub use event::{EntryEvent, Event, KeyEvent, NotebookEvent, NumKey};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod data;
 pub mod state;
 pub mod transition;
 pub mod types;
+pub mod proxy;
 
 pub use error::Error;
 pub use event::{EntryEvent, Event, KeyEvent, NotebookEvent, NumKey};

--- a/core/src/proxy/client.rs
+++ b/core/src/proxy/client.rs
@@ -1,10 +1,10 @@
 use super::request::ProxyRequest;
 use super::response::{ProxyResponse, ResultPayload};
 use crate::{
-    db::CoreBackend,
-    data::{Directory, Note},
-    types::{DirectoryId, NoteId},
     Error, Result,
+    data::{Directory, Note},
+    db::CoreBackend,
+    types::{DirectoryId, NoteId},
 };
 use async_trait::async_trait;
 use reqwest::Client;
@@ -19,11 +19,7 @@ impl ProxyClient {
     pub async fn connect<U: Into<String>>(url: U) -> Result<Self> {
         let url = url.into();
         let client = Client::new();
-        let resp = client
-            .post(&url)
-            .json(&ProxyRequest::RootId)
-            .send()
-            .await?;
+        let resp = client.post(&url).json(&ProxyRequest::RootId).send().await?;
         let resp: ProxyResponse = resp.json().await?;
         let root_id = match resp {
             ProxyResponse::Ok(ResultPayload::Id(id)) => id,
@@ -31,7 +27,11 @@ impl ProxyClient {
             _ => return Err(Error::Wip("invalid response".to_owned())),
         };
 
-        Ok(Self { url, client, root_id })
+        Ok(Self {
+            url,
+            client,
+            root_id,
+        })
     }
 
     async fn rpc(&self, req: ProxyRequest) -> Result<ProxyResponse> {
@@ -48,7 +48,10 @@ impl CoreBackend for ProxyClient {
     }
 
     async fn fetch_directory(&mut self, directory_id: DirectoryId) -> Result<Directory> {
-        match self.rpc(ProxyRequest::FetchDirectory { directory_id }).await? {
+        match self
+            .rpc(ProxyRequest::FetchDirectory { directory_id })
+            .await?
+        {
             ProxyResponse::Ok(ResultPayload::Directory(dir)) => Ok(dir),
             ProxyResponse::Err(e) => Err(Error::Wip(e)),
             _ => Err(Error::Wip("invalid response".to_owned())),
@@ -88,9 +91,16 @@ impl CoreBackend for ProxyClient {
         }
     }
 
-    async fn move_directory(&mut self, directory_id: DirectoryId, parent_id: DirectoryId) -> Result<()> {
+    async fn move_directory(
+        &mut self,
+        directory_id: DirectoryId,
+        parent_id: DirectoryId,
+    ) -> Result<()> {
         match self
-            .rpc(ProxyRequest::MoveDirectory { directory_id, parent_id })
+            .rpc(ProxyRequest::MoveDirectory {
+                directory_id,
+                parent_id,
+            })
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
@@ -119,10 +129,7 @@ impl CoreBackend for ProxyClient {
     }
 
     async fn fetch_note_content(&mut self, note_id: NoteId) -> Result<String> {
-        match self
-            .rpc(ProxyRequest::FetchNoteContent { note_id })
-            .await?
-        {
+        match self.rpc(ProxyRequest::FetchNoteContent { note_id }).await? {
             ProxyResponse::Ok(ResultPayload::Text(text)) => Ok(text),
             ProxyResponse::Err(e) => Err(Error::Wip(e)),
             _ => Err(Error::Wip("invalid response".to_owned())),
@@ -149,10 +156,7 @@ impl CoreBackend for ProxyClient {
     }
 
     async fn rename_note(&mut self, note_id: NoteId, name: String) -> Result<()> {
-        match self
-            .rpc(ProxyRequest::RenameNote { note_id, name })
-            .await?
-        {
+        match self.rpc(ProxyRequest::RenameNote { note_id, name }).await? {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
             ProxyResponse::Err(e) => Err(Error::Wip(e)),
             _ => Err(Error::Wip("invalid response".to_owned())),
@@ -172,7 +176,10 @@ impl CoreBackend for ProxyClient {
 
     async fn move_note(&mut self, note_id: NoteId, directory_id: DirectoryId) -> Result<()> {
         match self
-            .rpc(ProxyRequest::MoveNote { note_id, directory_id })
+            .rpc(ProxyRequest::MoveNote {
+                note_id,
+                directory_id,
+            })
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
@@ -182,10 +189,7 @@ impl CoreBackend for ProxyClient {
     }
 
     async fn log(&mut self, category: String, message: String) -> Result<()> {
-        match self
-            .rpc(ProxyRequest::Log { category, message })
-            .await?
-        {
+        match self.rpc(ProxyRequest::Log { category, message }).await? {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
             ProxyResponse::Err(e) => Err(Error::Wip(e)),
             _ => Err(Error::Wip("invalid response".to_owned())),

--- a/core/src/proxy/client.rs
+++ b/core/src/proxy/client.rs
@@ -1,0 +1,194 @@
+use super::request::ProxyRequest;
+use super::response::{ProxyResponse, ResultPayload};
+use crate::{
+    db::CoreBackend,
+    data::{Directory, Note},
+    types::{DirectoryId, NoteId},
+    Error, Result,
+};
+use async_trait::async_trait;
+use reqwest::Client;
+
+pub struct ProxyClient {
+    url: String,
+    client: Client,
+    root_id: DirectoryId,
+}
+
+impl ProxyClient {
+    pub async fn connect<U: Into<String>>(url: U) -> Result<Self> {
+        let url = url.into();
+        let client = Client::new();
+        let resp = client
+            .post(&url)
+            .json(&ProxyRequest::RootId)
+            .send()
+            .await?;
+        let resp: ProxyResponse = resp.json().await?;
+        let root_id = match resp {
+            ProxyResponse::Ok(ResultPayload::Id(id)) => id,
+            ProxyResponse::Err(e) => return Err(Error::Wip(e)),
+            _ => return Err(Error::Wip("invalid response".to_owned())),
+        };
+
+        Ok(Self { url, client, root_id })
+    }
+
+    async fn rpc(&self, req: ProxyRequest) -> Result<ProxyResponse> {
+        let resp = self.client.post(&self.url).json(&req).send().await?;
+        let resp: ProxyResponse = resp.json().await?;
+        Ok(resp)
+    }
+}
+
+#[async_trait(?Send)]
+impl CoreBackend for ProxyClient {
+    fn root_id(&self) -> DirectoryId {
+        self.root_id.clone()
+    }
+
+    async fn fetch_directory(&mut self, directory_id: DirectoryId) -> Result<Directory> {
+        match self.rpc(ProxyRequest::FetchDirectory { directory_id }).await? {
+            ProxyResponse::Ok(ResultPayload::Directory(dir)) => Ok(dir),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn fetch_directories(&mut self, parent_id: DirectoryId) -> Result<Vec<Directory>> {
+        match self
+            .rpc(ProxyRequest::FetchDirectories { parent_id })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Directories(dirs)) => Ok(dirs),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn add_directory(&mut self, parent_id: DirectoryId, name: String) -> Result<Directory> {
+        match self
+            .rpc(ProxyRequest::AddDirectory { parent_id, name })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Directory(dir)) => Ok(dir),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn remove_directory(&mut self, directory_id: DirectoryId) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::RemoveDirectory { directory_id })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn move_directory(&mut self, directory_id: DirectoryId, parent_id: DirectoryId) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::MoveDirectory { directory_id, parent_id })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn rename_directory(&mut self, directory_id: DirectoryId, name: String) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::RenameDirectory { directory_id, name })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn fetch_notes(&mut self, directory_id: DirectoryId) -> Result<Vec<Note>> {
+        match self.rpc(ProxyRequest::FetchNotes { directory_id }).await? {
+            ProxyResponse::Ok(ResultPayload::Notes(notes)) => Ok(notes),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn fetch_note_content(&mut self, note_id: NoteId) -> Result<String> {
+        match self
+            .rpc(ProxyRequest::FetchNoteContent { note_id })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Text(text)) => Ok(text),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn add_note(&mut self, directory_id: DirectoryId, name: String) -> Result<Note> {
+        match self
+            .rpc(ProxyRequest::AddNote { directory_id, name })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Note(note)) => Ok(note),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn remove_note(&mut self, note_id: NoteId) -> Result<()> {
+        match self.rpc(ProxyRequest::RemoveNote { note_id }).await? {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn rename_note(&mut self, note_id: NoteId, name: String) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::RenameNote { note_id, name })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn update_note_content(&mut self, note_id: NoteId, content: String) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::UpdateNoteContent { note_id, content })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn move_note(&mut self, note_id: NoteId, directory_id: DirectoryId) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::MoveNote { note_id, directory_id })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+
+    async fn log(&mut self, category: String, message: String) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::Log { category, message })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Wip(e)),
+            _ => Err(Error::Wip("invalid response".to_owned())),
+        }
+    }
+}

--- a/core/src/proxy/mod.rs
+++ b/core/src/proxy/mod.rs
@@ -1,0 +1,7 @@
+pub mod request;
+pub mod response;
+pub mod client;
+pub mod server;
+
+pub use client::ProxyClient;
+pub use server::ProxyServer;

--- a/core/src/proxy/mod.rs
+++ b/core/src/proxy/mod.rs
@@ -1,6 +1,6 @@
+pub mod client;
 pub mod request;
 pub mod response;
-pub mod client;
 pub mod server;
 
 pub use client::ProxyClient;

--- a/core/src/proxy/request.rs
+++ b/core/src/proxy/request.rs
@@ -5,18 +5,54 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "method", content = "data")]
 pub enum ProxyRequest {
     RootId,
-    FetchDirectory { directory_id: DirectoryId },
-    FetchDirectories { parent_id: DirectoryId },
-    AddDirectory { parent_id: DirectoryId, name: String },
-    RemoveDirectory { directory_id: DirectoryId },
-    MoveDirectory { directory_id: DirectoryId, parent_id: DirectoryId },
-    RenameDirectory { directory_id: DirectoryId, name: String },
-    FetchNotes { directory_id: DirectoryId },
-    FetchNoteContent { note_id: NoteId },
-    AddNote { directory_id: DirectoryId, name: String },
-    RemoveNote { note_id: NoteId },
-    RenameNote { note_id: NoteId, name: String },
-    UpdateNoteContent { note_id: NoteId, content: String },
-    MoveNote { note_id: NoteId, directory_id: DirectoryId },
-    Log { category: String, message: String },
+    FetchDirectory {
+        directory_id: DirectoryId,
+    },
+    FetchDirectories {
+        parent_id: DirectoryId,
+    },
+    AddDirectory {
+        parent_id: DirectoryId,
+        name: String,
+    },
+    RemoveDirectory {
+        directory_id: DirectoryId,
+    },
+    MoveDirectory {
+        directory_id: DirectoryId,
+        parent_id: DirectoryId,
+    },
+    RenameDirectory {
+        directory_id: DirectoryId,
+        name: String,
+    },
+    FetchNotes {
+        directory_id: DirectoryId,
+    },
+    FetchNoteContent {
+        note_id: NoteId,
+    },
+    AddNote {
+        directory_id: DirectoryId,
+        name: String,
+    },
+    RemoveNote {
+        note_id: NoteId,
+    },
+    RenameNote {
+        note_id: NoteId,
+        name: String,
+    },
+    UpdateNoteContent {
+        note_id: NoteId,
+        content: String,
+    },
+    MoveNote {
+        note_id: NoteId,
+        directory_id: DirectoryId,
+    },
+    Log {
+        category: String,
+        message: String,
+    },
 }

--- a/core/src/proxy/request.rs
+++ b/core/src/proxy/request.rs
@@ -1,0 +1,22 @@
+use crate::types::{DirectoryId, NoteId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "method", content = "data")]
+pub enum ProxyRequest {
+    RootId,
+    FetchDirectory { directory_id: DirectoryId },
+    FetchDirectories { parent_id: DirectoryId },
+    AddDirectory { parent_id: DirectoryId, name: String },
+    RemoveDirectory { directory_id: DirectoryId },
+    MoveDirectory { directory_id: DirectoryId, parent_id: DirectoryId },
+    RenameDirectory { directory_id: DirectoryId, name: String },
+    FetchNotes { directory_id: DirectoryId },
+    FetchNoteContent { note_id: NoteId },
+    AddNote { directory_id: DirectoryId, name: String },
+    RemoveNote { note_id: NoteId },
+    RenameNote { note_id: NoteId, name: String },
+    UpdateNoteContent { note_id: NoteId, content: String },
+    MoveNote { note_id: NoteId, directory_id: DirectoryId },
+    Log { category: String, message: String },
+}

--- a/core/src/proxy/response.rs
+++ b/core/src/proxy/response.rs
@@ -1,0 +1,22 @@
+use crate::data::{Directory, Note};
+use crate::types::DirectoryId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "status", content = "data")]
+pub enum ProxyResponse {
+    Ok(ResultPayload),
+    Err(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type", content = "value")]
+pub enum ResultPayload {
+    Id(DirectoryId),
+    Directory(Directory),
+    Directories(Vec<Directory>),
+    Note(Note),
+    Notes(Vec<Note>),
+    Text(String),
+    Unit,
+}

--- a/core/src/proxy/server.rs
+++ b/core/src/proxy/server.rs
@@ -26,22 +26,31 @@ where
                 Ok(dirs) => ProxyResponse::Ok(ResultPayload::Directories(dirs)),
                 Err(e) => ProxyResponse::Err(e.to_string()),
             },
-            AddDirectory { parent_id, name } => match self.db.add_directory(parent_id, name).await {
-                Ok(dir) => ProxyResponse::Ok(ResultPayload::Directory(dir)),
-                Err(e) => ProxyResponse::Err(e.to_string()),
-            },
-            RemoveDirectory { directory_id } => match self.db.remove_directory(directory_id).await {
+            AddDirectory { parent_id, name } => {
+                match self.db.add_directory(parent_id, name).await {
+                    Ok(dir) => ProxyResponse::Ok(ResultPayload::Directory(dir)),
+                    Err(e) => ProxyResponse::Err(e.to_string()),
+                }
+            }
+            RemoveDirectory { directory_id } => {
+                match self.db.remove_directory(directory_id).await {
+                    Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                    Err(e) => ProxyResponse::Err(e.to_string()),
+                }
+            }
+            MoveDirectory {
+                directory_id,
+                parent_id,
+            } => match self.db.move_directory(directory_id, parent_id).await {
                 Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
                 Err(e) => ProxyResponse::Err(e.to_string()),
             },
-            MoveDirectory { directory_id, parent_id } => match self.db.move_directory(directory_id, parent_id).await {
-                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
-                Err(e) => ProxyResponse::Err(e.to_string()),
-            },
-            RenameDirectory { directory_id, name } => match self.db.rename_directory(directory_id, name).await {
-                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
-                Err(e) => ProxyResponse::Err(e.to_string()),
-            },
+            RenameDirectory { directory_id, name } => {
+                match self.db.rename_directory(directory_id, name).await {
+                    Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                    Err(e) => ProxyResponse::Err(e.to_string()),
+                }
+            }
             FetchNotes { directory_id } => match self.db.fetch_notes(directory_id).await {
                 Ok(notes) => ProxyResponse::Ok(ResultPayload::Notes(notes)),
                 Err(e) => ProxyResponse::Err(e.to_string()),
@@ -62,11 +71,16 @@ where
                 Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
                 Err(e) => ProxyResponse::Err(e.to_string()),
             },
-            UpdateNoteContent { note_id, content } => match self.db.update_note_content(note_id, content).await {
-                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
-                Err(e) => ProxyResponse::Err(e.to_string()),
-            },
-            MoveNote { note_id, directory_id } => match self.db.move_note(note_id, directory_id).await {
+            UpdateNoteContent { note_id, content } => {
+                match self.db.update_note_content(note_id, content).await {
+                    Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                    Err(e) => ProxyResponse::Err(e.to_string()),
+                }
+            }
+            MoveNote {
+                note_id,
+                directory_id,
+            } => match self.db.move_note(note_id, directory_id).await {
                 Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
                 Err(e) => ProxyResponse::Err(e.to_string()),
             },

--- a/core/src/proxy/server.rs
+++ b/core/src/proxy/server.rs
@@ -1,0 +1,79 @@
+use super::request::ProxyRequest;
+use super::response::{ProxyResponse, ResultPayload};
+use crate::db::CoreBackend;
+
+pub struct ProxyServer<B> {
+    pub db: B,
+}
+
+impl<B> ProxyServer<B>
+where
+    B: CoreBackend,
+{
+    pub fn new(db: B) -> Self {
+        Self { db }
+    }
+
+    pub async fn handle(&mut self, req: ProxyRequest) -> ProxyResponse {
+        use ProxyRequest::*;
+        match req {
+            RootId => ProxyResponse::Ok(ResultPayload::Id(self.db.root_id())),
+            FetchDirectory { directory_id } => match self.db.fetch_directory(directory_id).await {
+                Ok(dir) => ProxyResponse::Ok(ResultPayload::Directory(dir)),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            FetchDirectories { parent_id } => match self.db.fetch_directories(parent_id).await {
+                Ok(dirs) => ProxyResponse::Ok(ResultPayload::Directories(dirs)),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            AddDirectory { parent_id, name } => match self.db.add_directory(parent_id, name).await {
+                Ok(dir) => ProxyResponse::Ok(ResultPayload::Directory(dir)),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            RemoveDirectory { directory_id } => match self.db.remove_directory(directory_id).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            MoveDirectory { directory_id, parent_id } => match self.db.move_directory(directory_id, parent_id).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            RenameDirectory { directory_id, name } => match self.db.rename_directory(directory_id, name).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            FetchNotes { directory_id } => match self.db.fetch_notes(directory_id).await {
+                Ok(notes) => ProxyResponse::Ok(ResultPayload::Notes(notes)),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            FetchNoteContent { note_id } => match self.db.fetch_note_content(note_id).await {
+                Ok(content) => ProxyResponse::Ok(ResultPayload::Text(content)),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            AddNote { directory_id, name } => match self.db.add_note(directory_id, name).await {
+                Ok(note) => ProxyResponse::Ok(ResultPayload::Note(note)),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            RemoveNote { note_id } => match self.db.remove_note(note_id).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            RenameNote { note_id, name } => match self.db.rename_note(note_id, name).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            UpdateNoteContent { note_id, content } => match self.db.update_note_content(note_id, content).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            MoveNote { note_id, directory_id } => match self.db.move_note(note_id, directory_id).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            Log { category, message } => match self.db.log(category, message).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+        }
+    }
+}

--- a/core/tests/proxy.rs
+++ b/core/tests/proxy.rs
@@ -1,0 +1,106 @@
+use glues_core::{
+    db::{CoreBackend, Db},
+    proxy::{ProxyClient, ProxyServer, request::ProxyRequest},
+};
+use std::{
+    net::TcpListener,
+    sync::{Arc, mpsc::channel},
+};
+use tiny_http::{Response, Server};
+use tokio::sync::Mutex;
+
+#[tokio::test(flavor = "current_thread")]
+async fn proxy_backend_operations() {
+    let (tx, _rx) = channel();
+    let db = Db::memory(tx).await.unwrap();
+    let server = ProxyServer::new(db);
+    let server = Arc::new(Mutex::new(server));
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let http = Arc::new(Server::from_listener(listener, None).unwrap());
+    let handle = tokio::runtime::Handle::current();
+    let srv = server.clone();
+    let http_clone = http.clone();
+    let server_thread = std::thread::spawn(move || {
+        for mut req in http_clone.incoming_requests() {
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).unwrap();
+            let proxy_req: ProxyRequest = serde_json::from_str(&body).unwrap();
+            let response = handle.block_on(async {
+                let mut s = srv.lock().await;
+                s.handle(proxy_req).await
+            });
+            let body = serde_json::to_string(&response).unwrap();
+            let resp = Response::from_string(body).with_header(
+                tiny_http::Header::from_bytes("Content-Type", "application/json").unwrap(),
+            );
+            let _ = req.respond(resp);
+        }
+    });
+
+    let mut client = ProxyClient::connect(format!("http://{}", addr))
+        .await
+        .unwrap();
+
+    let root_id = client.root_id();
+    let root = client.fetch_directory(root_id.clone()).await.unwrap();
+    assert_eq!(root.name, "Notes");
+
+    let dir = client
+        .add_directory(root_id.clone(), "Work".to_owned())
+        .await
+        .unwrap();
+    assert_eq!(dir.name, "Work");
+
+    let dirs = client.fetch_directories(root_id.clone()).await.unwrap();
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0].name, "Work");
+
+    let note = client
+        .add_note(dir.id.clone(), "Todo".to_owned())
+        .await
+        .unwrap();
+    assert_eq!(note.name, "Todo");
+
+    let notes = client.fetch_notes(dir.id.clone()).await.unwrap();
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].name, "Todo");
+
+    client
+        .update_note_content(note.id.clone(), "hello".to_owned())
+        .await
+        .unwrap();
+    let content = client.fetch_note_content(note.id.clone()).await.unwrap();
+    assert_eq!(content, "hello");
+
+    client
+        .rename_note(note.id.clone(), "Hello".to_owned())
+        .await
+        .unwrap();
+    let notes = client.fetch_notes(dir.id.clone()).await.unwrap();
+    assert_eq!(notes[0].name, "Hello");
+
+    client
+        .move_note(note.id.clone(), root_id.clone())
+        .await
+        .unwrap();
+    let notes_root = client.fetch_notes(root_id.clone()).await.unwrap();
+    assert_eq!(notes_root.len(), 1);
+
+    client.remove_note(note.id.clone()).await.unwrap();
+    let notes_root = client.fetch_notes(root_id.clone()).await.unwrap();
+    assert!(notes_root.is_empty());
+
+    client.remove_directory(dir.id.clone()).await.unwrap();
+    let dirs = client.fetch_directories(root_id.clone()).await.unwrap();
+    assert!(dirs.is_empty());
+
+    client
+        .log("test".to_owned(), "message".to_owned())
+        .await
+        .unwrap();
+
+    http.unblock();
+    server_thread.join().unwrap();
+}


### PR DESCRIPTION
## Summary
- add serde support for Note and Directory data structs
- extend `Error` with `Reqwest` variant
- add new proxy module containing request/response enums
- implement `ProxyClient` that talks to a proxy server via HTTP
- implement `ProxyServer` that delegates operations to a `CoreBackend`
- export proxy module and update dependencies

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68492e48f610832abe5752e67b5b1868