### PR TITLE
Refactor visual mode state - split into sub modules

### DIFF
--- a/core/src/state/notebook/inner_state/editing_visual_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode.rs
@@ -1,9 +1,13 @@
 use crate::{
-    Error, Event, KeyEvent, NumKey, Result,
+    Event, Result,
     db::CoreBackend,
-    state::notebook::{InnerState, NotebookState, VimNormalState},
-    transition::{NormalModeTransition, NotebookTransition, VimKeymapKind, VisualModeTransition},
+    state::notebook::NotebookState,
+    transition::{NotebookTransition, VisualModeTransition},
 };
+
+mod gateway;
+mod idle;
+mod numbering;
 
 #[derive(Clone, Copy)]
 pub enum VimVisualState {
@@ -19,186 +23,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
     event: Event,
 ) -> Result<NotebookTransition> {
     match vim_state {
-        VimVisualState::Idle => consume_idle(db, state, event).await,
-        VimVisualState::Gateway => consume_gateway(db, state, event).await,
-        VimVisualState::Numbering(n) => consume_numbering(db, state, n, event).await,
-    }
-}
-
-async fn consume_idle<B: CoreBackend + ?Sized>(
-    _db: &mut B,
-    state: &mut NotebookState,
-    event: Event,
-) -> Result<NotebookTransition> {
-    use Event::*;
-    use VisualModeTransition::*;
-
-    match event {
-        Key(KeyEvent::J | KeyEvent::Down) => MoveCursorDown(1).into(),
-        Key(KeyEvent::K | KeyEvent::Up) => MoveCursorUp(1).into(),
-        Key(KeyEvent::H | KeyEvent::Left) => MoveCursorBack(1).into(),
-        Key(KeyEvent::L | KeyEvent::Right) => MoveCursorForward(1).into(),
-        Key(KeyEvent::W) => MoveCursorWordForward(1).into(),
-        Key(KeyEvent::E) => MoveCursorWordEnd(1).into(),
-        Key(KeyEvent::B) => MoveCursorWordBack(1).into(),
-        Key(KeyEvent::Num(NumKey::Zero)) => MoveCursorLineStart.into(),
-        Key(KeyEvent::DollarSign) => MoveCursorLineEnd.into(),
-        Key(KeyEvent::Caret) => MoveCursorLineNonEmptyStart.into(),
-        Key(KeyEvent::CapG) => MoveCursorBottom.into(),
-        Key(KeyEvent::Tilde) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            SwitchCase.into()
-        }
-        Key(KeyEvent::U) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            ToLowercase.into()
-        }
-        Key(KeyEvent::CapU) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            ToUppercase.into()
-        }
-        Key(KeyEvent::D | KeyEvent::X) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            DeleteSelection.into()
-        }
-
-        Key(KeyEvent::S | KeyEvent::CapS) => {
-            state.inner_state = InnerState::EditingInsertMode;
-
-            DeleteSelectionAndInsertMode.into()
-        }
-        Key(KeyEvent::Y) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            YankSelection.into()
-        }
-        Key(KeyEvent::G) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Gateway);
-
-            GatewayMode.into()
-        }
-        Key(KeyEvent::Esc) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            Ok(NotebookTransition::EditingNormalMode(
-                NormalModeTransition::IdleMode,
-            ))
-        }
-        Key(KeyEvent::Num(n)) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Numbering(n.into()));
-
-            NumberingMode.into()
-        }
-        Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(VimKeymapKind::VisualIdle)),
-        event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
-    }
-}
-
-async fn consume_gateway<B: CoreBackend + ?Sized>(
-    db: &mut B,
-    state: &mut NotebookState,
-    event: Event,
-) -> Result<NotebookTransition> {
-    use Event::*;
-    use VisualModeTransition::*;
-
-    match event {
-        Key(KeyEvent::G) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorTop.into()
-        }
-        Key(KeyEvent::Esc) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            Ok(NotebookTransition::None)
-        }
-        event @ Key(_) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            consume_idle(db, state, event).await
-        }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
-    }
-}
-
-async fn consume_numbering<B: CoreBackend + ?Sized>(
-    db: &mut B,
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
-    use Event::*;
-    use VisualModeTransition::*;
-
-    match event {
-        Key(KeyEvent::Num(n2)) => {
-            let step = n2 + n.saturating_mul(10);
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Numbering(step));
-
-            Ok(NotebookTransition::None)
-        }
-        Key(KeyEvent::J | KeyEvent::Down) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorDown(n).into()
-        }
-        Key(KeyEvent::K | KeyEvent::Up) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorUp(n).into()
-        }
-        Key(KeyEvent::H | KeyEvent::Left) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            NormalModeTransition::MoveCursorBack(n).into()
-        }
-        Key(KeyEvent::L | KeyEvent::Right) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorForward(n).into()
-        }
-        Key(KeyEvent::W) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorWordForward(n).into()
-        }
-        Key(KeyEvent::E) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorWordEnd(n).into()
-        }
-        Key(KeyEvent::B) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorWordBack(n).into()
-        }
-        Key(KeyEvent::CapG) => {
-            state.inner_state = InnerState::EditingVisualMode(VimVisualState::Idle);
-
-            MoveCursorToLine(n).into()
-        }
-        Key(KeyEvent::Esc) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            Ok(NotebookTransition::EditingNormalMode(
-                NormalModeTransition::IdleMode,
-            ))
-        }
-        Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(
-            VimKeymapKind::VisualNumbering,
-        )),
-        event @ Key(_) => {
-            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
-
-            consume_idle(db, state, event).await
-        }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        VimVisualState::Idle => idle::consume(db, state, event).await,
+        VimVisualState::Gateway => gateway::consume(db, state, event).await,
+        VimVisualState::Numbering(n) => numbering::consume(db, state, n, event).await,
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
@@ -1,0 +1,34 @@
+use crate::{
+    Error, Event, KeyEvent, Result,
+    db::CoreBackend,
+    state::notebook::{InnerState, NotebookState, VimNormalState},
+    transition::{NotebookTransition, VisualModeTransition},
+};
+
+pub async fn consume<B: CoreBackend + ?Sized>(
+    db: &mut B,
+    state: &mut NotebookState,
+    event: Event,
+) -> Result<NotebookTransition> {
+    use Event::*;
+    use VisualModeTransition::*;
+
+    match event {
+        Key(KeyEvent::G) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorTop.into()
+        }
+        Key(KeyEvent::Esc) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            Ok(NotebookTransition::None)
+        }
+        event @ Key(_) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            super::idle::consume(db, state, event).await
+        }
+        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+    }
+}

--- a/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
@@ -1,0 +1,81 @@
+use crate::{
+    Error, Event, KeyEvent, NumKey, Result,
+    db::CoreBackend,
+    state::notebook::{InnerState, NotebookState, VimNormalState},
+    transition::{NormalModeTransition, NotebookTransition, VimKeymapKind, VisualModeTransition},
+};
+
+pub async fn consume<B: CoreBackend + ?Sized>(
+    _db: &mut B,
+    state: &mut NotebookState,
+    event: Event,
+) -> Result<NotebookTransition> {
+    use Event::*;
+    use VisualModeTransition::*;
+
+    match event {
+        Key(KeyEvent::J | KeyEvent::Down) => MoveCursorDown(1).into(),
+        Key(KeyEvent::K | KeyEvent::Up) => MoveCursorUp(1).into(),
+        Key(KeyEvent::H | KeyEvent::Left) => MoveCursorBack(1).into(),
+        Key(KeyEvent::L | KeyEvent::Right) => MoveCursorForward(1).into(),
+        Key(KeyEvent::W) => MoveCursorWordForward(1).into(),
+        Key(KeyEvent::E) => MoveCursorWordEnd(1).into(),
+        Key(KeyEvent::B) => MoveCursorWordBack(1).into(),
+        Key(KeyEvent::Num(NumKey::Zero)) => MoveCursorLineStart.into(),
+        Key(KeyEvent::DollarSign) => MoveCursorLineEnd.into(),
+        Key(KeyEvent::Caret) => MoveCursorLineNonEmptyStart.into(),
+        Key(KeyEvent::CapG) => MoveCursorBottom.into(),
+        Key(KeyEvent::Tilde) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            SwitchCase.into()
+        }
+        Key(KeyEvent::U) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            ToLowercase.into()
+        }
+        Key(KeyEvent::CapU) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            ToUppercase.into()
+        }
+        Key(KeyEvent::D | KeyEvent::X) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            DeleteSelection.into()
+        }
+
+        Key(KeyEvent::S | KeyEvent::CapS) => {
+            state.inner_state = InnerState::EditingInsertMode;
+
+            DeleteSelectionAndInsertMode.into()
+        }
+        Key(KeyEvent::Y) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            YankSelection.into()
+        }
+        Key(KeyEvent::G) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Gateway);
+
+            GatewayMode.into()
+        }
+        Key(KeyEvent::Esc) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            Ok(NotebookTransition::EditingNormalMode(
+                NormalModeTransition::IdleMode,
+            ))
+        }
+        Key(KeyEvent::Num(n)) => {
+            state.inner_state =
+                InnerState::EditingVisualMode(super::VimVisualState::Numbering(n.into()));
+
+            NumberingMode.into()
+        }
+        Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(VimKeymapKind::VisualIdle)),
+        event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
+        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+    }
+}

--- a/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
@@ -1,0 +1,82 @@
+use crate::{
+    Error, Event, KeyEvent, Result,
+    db::CoreBackend,
+    state::notebook::{InnerState, NotebookState, VimNormalState},
+    transition::{NormalModeTransition, NotebookTransition, VimKeymapKind, VisualModeTransition},
+};
+
+pub async fn consume<B: CoreBackend + ?Sized>(
+    db: &mut B,
+    state: &mut NotebookState,
+    n: usize,
+    event: Event,
+) -> Result<NotebookTransition> {
+    use Event::*;
+    use VisualModeTransition::*;
+
+    match event {
+        Key(KeyEvent::Num(n2)) => {
+            let step = n2 + n.saturating_mul(10);
+            state.inner_state =
+                InnerState::EditingVisualMode(super::VimVisualState::Numbering(step));
+
+            Ok(NotebookTransition::None)
+        }
+        Key(KeyEvent::J | KeyEvent::Down) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorDown(n).into()
+        }
+        Key(KeyEvent::K | KeyEvent::Up) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorUp(n).into()
+        }
+        Key(KeyEvent::H | KeyEvent::Left) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            NormalModeTransition::MoveCursorBack(n).into()
+        }
+        Key(KeyEvent::L | KeyEvent::Right) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorForward(n).into()
+        }
+        Key(KeyEvent::W) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorWordForward(n).into()
+        }
+        Key(KeyEvent::E) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorWordEnd(n).into()
+        }
+        Key(KeyEvent::B) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorWordBack(n).into()
+        }
+        Key(KeyEvent::CapG) => {
+            state.inner_state = InnerState::EditingVisualMode(super::VimVisualState::Idle);
+
+            MoveCursorToLine(n).into()
+        }
+        Key(KeyEvent::Esc) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            Ok(NotebookTransition::EditingNormalMode(
+                NormalModeTransition::IdleMode,
+            ))
+        }
+        Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(
+            VimKeymapKind::VisualNumbering,
+        )),
+        event @ Key(_) => {
+            state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
+
+            super::idle::consume(db, state, event).await
+        }
+        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+    }
+}


### PR DESCRIPTION
## Summary
- split visual mode consume functions into submodules
- rename the root file to `editing_visual_mode.rs`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68493bba4448832a98dd41f3d48c98ff