### PR TITLE
Add scrollbar support for keymap dialog

### DIFF
--- a/tui/src/context.rs
+++ b/tui/src/context.rs
@@ -8,7 +8,7 @@ use {
         crossterm::event::{Event as Input, KeyCode, KeyEvent},
         style::Style,
         text::Line,
-        widgets::{Block, Borders},
+        widgets::{Block, Borders, ScrollbarState},
     },
     std::time::SystemTime,
     tui_textarea::TextArea,
@@ -59,6 +59,8 @@ pub struct Context {
     pub vim_keymap: Option<VimKeymapKind>,
 
     pub keymap: bool,
+    pub keymap_scroll: usize,
+    pub keymap_scroll_state: ScrollbarState,
 }
 
 impl Default for Context {
@@ -78,6 +80,8 @@ impl Default for Context {
             vim_keymap: None,
 
             keymap: false,
+            keymap_scroll: 0,
+            keymap_scroll_state: ScrollbarState::new(0),
         }
     }
 }
@@ -146,6 +150,22 @@ impl Context {
                         .input(input.clone());
 
                     return Action::None;
+                }
+            }
+        }
+
+        if self.keymap {
+            if let Input::Key(KeyEvent { code, .. }) = input {
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        self.keymap_scroll = self.keymap_scroll.saturating_add(1);
+                        return Action::None;
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.keymap_scroll = self.keymap_scroll.saturating_sub(1);
+                        return Action::None;
+                    }
+                    _ => {}
                 }
             }
         }

--- a/tui/src/transitions/keymap.rs
+++ b/tui/src/transitions/keymap.rs
@@ -1,10 +1,12 @@
-use {crate::App, glues_core::transition::KeymapTransition};
+use {crate::App, glues_core::transition::KeymapTransition, ratatui::widgets::ScrollbarState};
 
 impl App {
     pub(super) async fn handle_keymap_transition(&mut self, transition: KeymapTransition) {
         match transition {
             KeymapTransition::Show => {
                 self.context.keymap = true;
+                self.context.keymap_scroll = 0;
+                self.context.keymap_scroll_state = ScrollbarState::new(0);
             }
             KeymapTransition::Hide => {
                 self.context.keymap = false;

--- a/tui/src/views/dialog.rs
+++ b/tui/src/views/dialog.rs
@@ -19,7 +19,7 @@ use {
 
 pub fn draw(frame: &mut Frame, state: &State, context: &mut Context) {
     if context.keymap {
-        keymap::draw(frame, state.keymap().as_slice());
+        keymap::draw(frame, context, state.keymap().as_slice());
     }
 
     if let Some(kind) = context.vim_keymap {


### PR DESCRIPTION
## Summary
- allow scrolling in the keymap dialog using `ratatui`'s `Scrollbar`
- track scroll position in `Context`
- reset scroll when showing keymap

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684a535ff510832aafa4a9506109ab6d