### PR TITLE
Add detailed error variants to replace Error::Wip

### DIFF
--- a/core/src/db/note.rs
+++ b/core/src/db/note.rs
@@ -19,12 +19,12 @@ impl Db {
             .execute(&mut self.storage)
             .await?
             .select()
-            .ok_or(Error::Wip("error case 2".to_owned()))?
+            .ok_or(Error::NotFound("note not found".to_owned()))?
             .next()
-            .ok_or(Error::Wip("error case 3".to_owned()))?
+            .ok_or(Error::NotFound("note not found".to_owned()))?
             .get("content")
             .map(Deref::deref)
-            .ok_or(Error::Wip("error case 4".to_owned()))?
+            .ok_or(Error::NotFound("content not found".to_owned()))?
             .into();
 
         Ok(content)

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -8,6 +8,18 @@ pub enum Error {
     #[error("reqwest: {0}")]
     Reqwest(#[from] reqwest::Error),
 
-    #[error("wip: {0}")]
-    Wip(String),
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+
+    #[error("invalid state: {0}")]
+    InvalidState(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("todo: {0}")]
+    Todo(String),
+
+    #[error("proxy: {0}")]
+    Proxy(String),
 }

--- a/core/src/proxy/client.rs
+++ b/core/src/proxy/client.rs
@@ -23,8 +23,8 @@ impl ProxyClient {
         let resp: ProxyResponse = resp.json().await?;
         let root_id = match resp {
             ProxyResponse::Ok(ResultPayload::Id(id)) => id,
-            ProxyResponse::Err(e) => return Err(Error::Wip(e)),
-            _ => return Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => return Err(Error::Proxy(e)),
+            _ => return Err(Error::InvalidResponse("invalid response".to_owned())),
         };
 
         Ok(Self {
@@ -53,8 +53,8 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Directory(dir)) => Ok(dir),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -64,8 +64,8 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Directories(dirs)) => Ok(dirs),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -75,8 +75,8 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Directory(dir)) => Ok(dir),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -86,8 +86,8 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -104,8 +104,8 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -115,24 +115,24 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
     async fn fetch_notes(&mut self, directory_id: DirectoryId) -> Result<Vec<Note>> {
         match self.rpc(ProxyRequest::FetchNotes { directory_id }).await? {
             ProxyResponse::Ok(ResultPayload::Notes(notes)) => Ok(notes),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
     async fn fetch_note_content(&mut self, note_id: NoteId) -> Result<String> {
         match self.rpc(ProxyRequest::FetchNoteContent { note_id }).await? {
             ProxyResponse::Ok(ResultPayload::Text(text)) => Ok(text),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -142,24 +142,24 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Note(note)) => Ok(note),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
     async fn remove_note(&mut self, note_id: NoteId) -> Result<()> {
         match self.rpc(ProxyRequest::RemoveNote { note_id }).await? {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
     async fn rename_note(&mut self, note_id: NoteId, name: String) -> Result<()> {
         match self.rpc(ProxyRequest::RenameNote { note_id, name }).await? {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -169,8 +169,8 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
@@ -183,16 +183,16 @@ impl CoreBackend for ProxyClient {
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 
     async fn log(&mut self, category: String, message: String) -> Result<()> {
         match self.rpc(ProxyRequest::Log { category, message }).await? {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
-            ProxyResponse::Err(e) => Err(Error::Wip(e)),
-            _ => Err(Error::Wip("invalid response".to_owned())),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
         }
     }
 }

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -101,5 +101,5 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .get("id")
         .map(Deref::deref)
         .map(Into::into)
-        .ok_or(Error::Wip("empty id".to_owned()))
+        .ok_or(Error::NotFound("empty id".to_owned()))
 }

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -67,15 +67,15 @@ macro_rules! impl_state_ext {
             fn get_inner(&self) -> Result<&$State> {
                 match &self.inner {
                     InnerState::$State(state) => Ok(&state),
-                    _ => Err(Error::Wip("State::get_inner for $State failed".to_owned())),
+                    _ => Err(Error::InvalidState("State::get_inner failed".to_owned())),
                 }
             }
 
             fn get_inner_mut(&mut self) -> Result<&mut $State> {
                 match &mut self.inner {
                     InnerState::$State(state) => Ok(state),
-                    _ => Err(Error::Wip(
-                        "State::get_inner_mut for $State failed".to_owned(),
+                    _ => Err(Error::InvalidState(
+                        "State::get_inner_mut failed".to_owned(),
                     )),
                 }
             }

--- a/core/src/state/entry.rs
+++ b/core/src/state/entry.rs
@@ -63,7 +63,7 @@ impl EntryState {
             }
             Key(_) => Ok(EntryTransition::Inedible(event)),
             Cancel => Ok(EntryTransition::None),
-            _ => Err(Error::Wip("todo: EntryState::consume".to_owned())),
+            _ => Err(Error::Todo("EntryState::consume".to_owned())),
         }
     }
 

--- a/core/src/state/notebook.rs
+++ b/core/src/state/notebook.rs
@@ -45,7 +45,7 @@ impl NotebookState {
         let db = glues
             .db
             .as_mut()
-            .ok_or(Error::Wip("[NotebookState::new] empty db".to_owned()))?;
+            .ok_or(Error::InvalidState("[NotebookState::new] empty db".to_owned()))?;
         let root_id = db.root_id.clone();
         let root_directory = db.fetch_directory(root_id).await?;
         let notes = db.fetch_notes(root_directory.id.clone()).await?;
@@ -266,14 +266,14 @@ impl NotebookState {
     pub fn get_selected_note(&self) -> Result<&Note> {
         match &self.selected {
             SelectedItem::Note(note) => Ok(note),
-            _ => Err(Error::Wip("selected note not found".to_owned())),
+            _ => Err(Error::InvalidState("selected note not found".to_owned())),
         }
     }
 
     pub fn get_selected_directory(&self) -> Result<&Directory> {
         match &self.selected {
             SelectedItem::Directory(directory) => Ok(directory),
-            _ => Err(Error::Wip("selected directory not found".to_owned())),
+            _ => Err(Error::InvalidState("selected directory not found".to_owned())),
         }
     }
 
@@ -281,18 +281,18 @@ impl NotebookState {
         match &self.selected {
             SelectedItem::Note(note) => Ok(&note.id),
             SelectedItem::Directory(directory) => Ok(&directory.id),
-            _ => Err(Error::Wip("selected item not found".to_owned())),
+            _ => Err(Error::InvalidState("selected item not found".to_owned())),
         }
     }
 
     pub fn get_editing(&self) -> Result<&Note> {
         let i = self
             .tab_index
-            .ok_or_else(|| Error::Wip("tab index is none".to_owned()))?;
+            .ok_or_else(|| Error::InvalidState("tab index is none".to_owned()))?;
         self.tabs
             .get(i)
             .map(|tab| &tab.note)
-            .ok_or_else(|| Error::Wip("tab not found".to_owned()))
+            .ok_or_else(|| Error::NotFound("tab not found".to_owned()))
     }
 }
 
@@ -300,7 +300,7 @@ pub async fn consume(glues: &mut Glues, event: Event) -> Result<NotebookTransiti
     let db = glues
         .db
         .as_mut()
-        .ok_or(Error::Wip("[consume] empty db".to_owned()))?;
+        .ok_or(Error::InvalidState("[consume] empty db".to_owned()))?;
     let state: &mut NotebookState = glues.state.get_inner_mut()?;
 
     inner_state::consume(db, state, event).await

--- a/core/src/state/notebook.rs
+++ b/core/src/state/notebook.rs
@@ -42,10 +42,9 @@ pub enum SelectedItem {
 
 impl NotebookState {
     pub async fn new(glues: &mut Glues) -> Result<Self> {
-        let db = glues
-            .db
-            .as_mut()
-            .ok_or(Error::InvalidState("[NotebookState::new] empty db".to_owned()))?;
+        let db = glues.db.as_mut().ok_or(Error::InvalidState(
+            "[NotebookState::new] empty db".to_owned(),
+        ))?;
         let root_id = db.root_id.clone();
         let root_directory = db.fetch_directory(root_id).await?;
         let notes = db.fetch_notes(root_directory.id.clone()).await?;
@@ -273,7 +272,9 @@ impl NotebookState {
     pub fn get_selected_directory(&self) -> Result<&Directory> {
         match &self.selected {
             SelectedItem::Directory(directory) => Ok(directory),
-            _ => Err(Error::InvalidState("selected directory not found".to_owned())),
+            _ => Err(Error::InvalidState(
+                "selected directory not found".to_owned(),
+            )),
         }
     }
 

--- a/core/src/state/notebook/consume/breadcrumb.rs
+++ b/core/src/state/notebook/consume/breadcrumb.rs
@@ -24,7 +24,7 @@ pub(super) async fn update_breadcrumbs<B: CoreBackend + ?Sized>(
             .iter()
             .enumerate()
             .find_map(|(i, item)| (item.id == &tab.note.id).then_some((i, item.depth)))
-            .ok_or(Error::Wip(format!(
+            .ok_or(Error::NotFound(format!(
                 "[breadcrumb::update_breadcrumbs] note not found: {}",
                 tab.note.name
             )))?;

--- a/core/src/state/notebook/consume/directory.rs
+++ b/core/src/state/notebook/consume/directory.rs
@@ -21,7 +21,7 @@ pub async fn open<B: CoreBackend + ?Sized>(
     let item = state
         .root
         .find_mut(&directory_id)
-        .ok_or(Error::Wip(format!(
+        .ok_or(Error::NotFound(format!(
             "[directory::open] directory not found: {directory_id}"
         )))?;
 
@@ -84,7 +84,7 @@ pub fn close(state: &mut NotebookState, directory: Directory) -> Result<Notebook
     state
         .root
         .find_mut(&directory.id)
-        .ok_or(Error::Wip(format!(
+        .ok_or(Error::NotFound(format!(
             "[directory::close] failed to find directory '{}'",
             directory.name
         )))?
@@ -143,7 +143,7 @@ pub async fn rename<B: CoreBackend + ?Sized>(
     .await?;
 
     directory.name = new_name;
-    state.root.rename_directory(&directory).ok_or(Error::Wip(
+    state.root.rename_directory(&directory).ok_or(Error::NotFound(
         "[directory::rename] failed to find directory".to_owned(),
     ))?;
     state.inner_state = InnerState::NoteTree(NoteTreeState::DirectorySelected);
@@ -171,7 +171,7 @@ pub async fn remove<B: CoreBackend + ?Sized>(
     let selected_directory = state
         .root
         .remove_directory(&directory)
-        .ok_or(Error::Wip(
+        .ok_or(Error::NotFound(
             "[directory::remove] failed to find parent directory".to_owned(),
         ))?
         .clone();
@@ -196,7 +196,7 @@ pub async fn add<B: CoreBackend + ?Sized>(
     let parent_id = directory.id.clone();
     let directory = db.add_directory(parent_id.clone(), directory_name).await?;
 
-    let item = state.root.find_mut(&parent_id).ok_or(Error::Wip(format!(
+    let item = state.root.find_mut(&parent_id).ok_or(Error::NotFound(format!(
         "[directory::add] parent directory not found: {}",
         parent_id
     )))?;

--- a/core/src/state/notebook/consume/directory.rs
+++ b/core/src/state/notebook/consume/directory.rs
@@ -143,9 +143,12 @@ pub async fn rename<B: CoreBackend + ?Sized>(
     .await?;
 
     directory.name = new_name;
-    state.root.rename_directory(&directory).ok_or(Error::NotFound(
-        "[directory::rename] failed to find directory".to_owned(),
-    ))?;
+    state
+        .root
+        .rename_directory(&directory)
+        .ok_or(Error::NotFound(
+            "[directory::rename] failed to find directory".to_owned(),
+        ))?;
     state.inner_state = InnerState::NoteTree(NoteTreeState::DirectorySelected);
 
     breadcrumb::update_breadcrumbs(db, state).await?;
@@ -196,10 +199,13 @@ pub async fn add<B: CoreBackend + ?Sized>(
     let parent_id = directory.id.clone();
     let directory = db.add_directory(parent_id.clone(), directory_name).await?;
 
-    let item = state.root.find_mut(&parent_id).ok_or(Error::NotFound(format!(
-        "[directory::add] parent directory not found: {}",
-        parent_id
-    )))?;
+    let item = state
+        .root
+        .find_mut(&parent_id)
+        .ok_or(Error::NotFound(format!(
+            "[directory::add] parent directory not found: {}",
+            parent_id
+        )))?;
 
     if let DirectoryItem {
         children: Some(children),

--- a/core/src/state/notebook/consume/note.rs
+++ b/core/src/state/notebook/consume/note.rs
@@ -42,7 +42,7 @@ pub async fn rename<B: CoreBackend + ?Sized>(
     .await?;
 
     note.name = new_name;
-    state.root.rename_note(&note).ok_or(Error::Wip(
+    state.root.rename_note(&note).ok_or(Error::NotFound(
         "[note::rename] failed to find parent directory".to_owned(),
     ))?;
 
@@ -67,7 +67,7 @@ pub async fn remove<B: CoreBackend + ?Sized>(
 ) -> Result<NotebookTransition> {
     db.remove_note(note.id.clone()).await?;
 
-    let directory = state.root.remove_note(&note).ok_or(Error::Wip(
+    let directory = state.root.remove_note(&note).ok_or(Error::NotFound(
         "[note::remove] failed to find parent directory".to_owned(),
     ))?;
 
@@ -93,7 +93,7 @@ pub async fn add<B: CoreBackend + ?Sized>(
     let item = state
         .root
         .find_mut(&directory.id)
-        .ok_or(Error::Wip(format!(
+        .ok_or(Error::NotFound(format!(
             "[note::add] directory not found: {}",
             directory.id
         )))?;

--- a/core/src/state/notebook/consume/tabs.rs
+++ b/core/src/state/notebook/consume/tabs.rs
@@ -18,7 +18,7 @@ pub async fn select_prev<B: CoreBackend + ?Sized>(
 
     let i = state
         .tab_index
-        .ok_or(Error::Wip("opened note must exist".to_owned()))?;
+        .ok_or(Error::InvalidState("opened note must exist".to_owned()))?;
     let i = if i == 0 { state.tabs.len() - 1 } else { i - 1 };
     state.tab_index = Some(i);
 
@@ -42,7 +42,7 @@ pub async fn select_next<B: CoreBackend + ?Sized>(
 
     let i = state
         .tab_index
-        .ok_or(Error::Wip("opened note must exist".to_owned()))?;
+        .ok_or(Error::InvalidState("opened note must exist".to_owned()))?;
     let i = if i + 1 >= state.tabs.len() { 0 } else { i + 1 };
     state.tab_index = Some(i);
 
@@ -61,7 +61,7 @@ pub async fn select_next<B: CoreBackend + ?Sized>(
 pub fn move_prev(state: &mut NotebookState) -> Result<NotebookTransition> {
     let i = state
         .tab_index
-        .ok_or(Error::Wip("opened note must exist".to_owned()))?;
+        .ok_or(Error::InvalidState("opened note must exist".to_owned()))?;
 
     if i == 0 {
         return Ok(NotebookTransition::None);
@@ -79,7 +79,7 @@ pub fn move_prev(state: &mut NotebookState) -> Result<NotebookTransition> {
 pub fn move_next(state: &mut NotebookState) -> Result<NotebookTransition> {
     let i = state
         .tab_index
-        .ok_or(Error::Wip("opened note must exist".to_owned()))?;
+        .ok_or(Error::InvalidState("opened note must exist".to_owned()))?;
 
     if i >= state.tabs.len() - 1 {
         return Ok(NotebookTransition::None);
@@ -101,7 +101,7 @@ pub async fn close<B: CoreBackend + ?Sized>(
     state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
     let i = state
         .tab_index
-        .ok_or(Error::Wip("opened note must exist".to_owned()))?;
+        .ok_or(Error::InvalidState("opened note must exist".to_owned()))?;
 
     let note_id = state.tabs[i].note.id.clone();
     state.tabs.retain(|tab| tab.note.id != note_id);

--- a/core/src/state/notebook/inner_state/editing_insert_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_insert_mode.rs
@@ -16,7 +16,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
     match event {
         Key(KeyEvent::Esc) | Notebook(ViewNote) => note::view(state).await,
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change.rs
@@ -55,7 +55,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change2.rs
@@ -62,7 +62,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change_inside.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change_inside.rs
@@ -24,7 +24,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete.rs
@@ -81,7 +81,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete2.rs
@@ -77,7 +77,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete_inside.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete_inside.rs
@@ -24,7 +24,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/gateway.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/gateway.rs
@@ -26,7 +26,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
@@ -120,7 +120,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
         }
         Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(VimKeymapKind::NormalIdle)),
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/numbering.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/numbering.rs
@@ -104,7 +104,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/scroll.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/scroll.rs
@@ -30,7 +30,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/toggle.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/toggle.rs
@@ -41,7 +41,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/toggle_tab_close.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/toggle_tab_close.rs
@@ -11,7 +11,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
     match event {
         Key(KeyEvent::L) => {
-            let i = state.tab_index.ok_or(Error::Wip(
+            let i = state.tab_index.ok_or(Error::InvalidState(
                 "[ToggleTabClose::L] tab index must exist".to_owned(),
             ))? + 1;
 
@@ -21,7 +21,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
             CloseRightTabs(i).into()
         }
         Key(KeyEvent::H) => {
-            let i = state.tab_index.ok_or(Error::Wip(
+            let i = state.tab_index.ok_or(Error::InvalidState(
                 "[ToggleTabClose::H] tab index must exist".to_owned(),
             ))?;
 
@@ -36,7 +36,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/yank.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/yank.rs
@@ -35,7 +35,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/yank2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/yank2.rs
@@ -36,7 +36,7 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
@@ -30,7 +30,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             super::idle::consume(db, state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
@@ -77,7 +77,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         }
         Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(VimKeymapKind::VisualIdle)),
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
@@ -78,7 +78,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             super::idle::consume(db, state, event).await
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/directory_more_actions.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_more_actions.rs
@@ -45,7 +45,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             directory::select(state, directory)
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
@@ -21,7 +21,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Notebook(OpenDirectory(directory_id)) => directory::open(db, state, directory_id).await,
         Key(KeyEvent::L | KeyEvent::Right | KeyEvent::Enter) => {
             let directory = state.get_selected_directory()?.clone();
-            let directory_item = state.root.find(&directory.id).ok_or(Error::Wip(
+            let directory_item = state.root.find(&directory.id).ok_or(Error::NotFound(
                 "[Key::L] failed to find the target directory".to_owned(),
             ))?;
 
@@ -35,7 +35,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             let directory = state
                 .root
                 .find(&directory_id)
-                .ok_or(Error::Wip(
+                .ok_or(Error::NotFound(
                     "[CloseDirectory] failed to find target directory".to_owned(),
                 ))?
                 .directory
@@ -49,7 +49,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
                 return Ok(NotebookTransition::None);
             }
 
-            let parent_item = state.root.find(&directory.parent_id).ok_or(Error::Wip(
+            let parent_item = state.root.find(&directory.parent_id).ok_or(Error::NotFound(
                 "[Key::H] failed to find parent directory".to_owned(),
             ))?;
             let parent = parent_item.directory.clone();
@@ -103,7 +103,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         )),
         Key(KeyEvent::Tab) if !state.tabs.is_empty() => tabs::focus_editor(db, state).await,
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
@@ -49,9 +49,12 @@ pub async fn consume<B: CoreBackend + ?Sized>(
                 return Ok(NotebookTransition::None);
             }
 
-            let parent_item = state.root.find(&directory.parent_id).ok_or(Error::NotFound(
-                "[Key::H] failed to find parent directory".to_owned(),
-            ))?;
+            let parent_item = state
+                .root
+                .find(&directory.parent_id)
+                .ok_or(Error::NotFound(
+                    "[Key::H] failed to find parent directory".to_owned(),
+                ))?;
             let parent = parent_item.directory.clone();
 
             directory::close(state, parent)

--- a/core/src/state/notebook/inner_state/note_tree/gateway.rs
+++ b/core/src/state/notebook/inner_state/note_tree/gateway.rs
@@ -26,9 +26,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
             Ok(NotebookTransition::Inedible(event))
         }
-        _ => Err(Error::Wip(
-            "todo: NoteTree::GatewayMode::consume".to_owned(),
-        )),
+        _ => Err(Error::Todo("NoteTree::GatewayMode::consume".to_owned())),
     }
 }
 
@@ -36,7 +34,7 @@ fn leave_gateway_mode(selected: &SelectedItem) -> Result<InnerState> {
     match selected {
         SelectedItem::Directory(_) => Ok(InnerState::NoteTree(NoteTreeState::DirectorySelected)),
         SelectedItem::Note(_) => Ok(InnerState::NoteTree(NoteTreeState::NoteSelected)),
-        SelectedItem::None => Err(Error::Wip("todo: cannot leave gateway mode".to_owned())),
+        SelectedItem::None => Err(Error::Todo("cannot leave gateway mode".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/move_mode.rs
+++ b/core/src/state/notebook/inner_state/note_tree/move_mode.rs
@@ -41,7 +41,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             directory::move_directory(db, state, target_directory_id).await
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/note_more_actions.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_more_actions.rs
@@ -35,7 +35,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             note::select(state, note.clone())
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/note_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_selected.rs
@@ -23,7 +23,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             let directory = state
                 .root
                 .find(&directory_id)
-                .ok_or(Error::Wip(
+                .ok_or(Error::NotFound(
                     "[CloseDirectory] failed to find target directory".to_owned(),
                 ))?
                 .directory
@@ -33,7 +33,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         }
         Key(KeyEvent::H) | Key(KeyEvent::Left) => {
             let directory_id = &state.get_selected_note()?.directory_id;
-            let directory_item = state.root.find(directory_id).ok_or(Error::Wip(
+            let directory_item = state.root.find(directory_id).ok_or(Error::NotFound(
                 "[Key::H] failed to find parent directory".to_owned(),
             ))?;
             let directory = directory_item.directory.clone();
@@ -92,7 +92,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         )),
         Key(KeyEvent::Tab) if !state.tabs.is_empty() => tabs::focus_editor(db, state).await,
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/numbering.rs
+++ b/core/src/state/notebook/inner_state/note_tree/numbering.rs
@@ -73,7 +73,7 @@ pub async fn consume(
             reset_state(state);
             Ok(NotebookTransition::Inedible(event))
         }
-        _ => Err(Error::Wip("todo: Notebook::consume".to_owned())),
+        _ => Err(Error::Todo("Notebook::consume".to_owned())),
     }
 }
 


### PR DESCRIPTION
## Summary
- add detailed error variants to replace `Error::Wip`
- refactor modules to use new `InvalidState`, `NotFound`, `InvalidResponse`, `Todo`, and `Proxy` errors

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684a5c504f8c832ab859765c455f8808