### PR TITLE
Improve Error::Todo messages for better debugging

### DIFF
--- a/core/src/state/notebook/inner_state/editing_insert_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_insert_mode.rs
@@ -16,7 +16,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
     match event {
         Key(KeyEvent::Esc) | Notebook(ViewNote) => note::view(state).await,
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingInsertMode::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change.rs
@@ -55,7 +55,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Change::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change2.rs
@@ -62,7 +62,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Change2::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change_inside.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change_inside.rs
@@ -24,7 +24,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::ChangeInside::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete.rs
@@ -81,7 +81,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Delete::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete2.rs
@@ -77,7 +77,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Delete2::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete_inside.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete_inside.rs
@@ -24,7 +24,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::DeleteInside::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/gateway.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/gateway.rs
@@ -26,7 +26,9 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Gateway::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
@@ -120,7 +120,9 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
         }
         Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(VimKeymapKind::NormalIdle)),
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Idle::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/numbering.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/numbering.rs
@@ -104,7 +104,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Numbering::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/scroll.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/scroll.rs
@@ -30,7 +30,9 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Scroll::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/toggle.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/toggle.rs
@@ -41,7 +41,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Toggle::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/toggle_tab_close.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/toggle_tab_close.rs
@@ -36,7 +36,9 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::ToggleTabClose::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/yank.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/yank.rs
@@ -35,7 +35,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Yank::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/yank2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/yank2.rs
@@ -36,7 +36,9 @@ pub async fn consume(
 
             super::idle::consume(state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingNormalMode::Yank2::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
@@ -30,7 +30,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             super::idle::consume(db, state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingVisualMode::Gateway::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
@@ -77,7 +77,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         }
         Key(KeyEvent::CtrlH) => Ok(NotebookTransition::ShowVimKeymap(VimKeymapKind::VisualIdle)),
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingVisualMode::Idle::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
@@ -78,7 +78,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             super::idle::consume(db, state, event).await
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::EditingVisualMode::Numbering::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/directory_more_actions.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_more_actions.rs
@@ -45,7 +45,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             directory::select(state, directory)
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::NoteTree::DirectoryMoreActions::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
@@ -106,7 +106,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         )),
         Key(KeyEvent::Tab) if !state.tabs.is_empty() => tabs::focus_editor(db, state).await,
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::NoteTree::DirectorySelected::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/move_mode.rs
+++ b/core/src/state/notebook/inner_state/note_tree/move_mode.rs
@@ -41,7 +41,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             directory::move_directory(db, state, target_directory_id).await
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::NoteTree::MoveMode::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/note_more_actions.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_more_actions.rs
@@ -35,7 +35,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
             note::select(state, note.clone())
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::NoteTree::NoteMoreActions::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/note_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_selected.rs
@@ -92,7 +92,9 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         )),
         Key(KeyEvent::Tab) if !state.tabs.is_empty() => tabs::focus_editor(db, state).await,
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::NoteTree::NoteSelected::consume".to_owned(),
+        )),
     }
 }
 

--- a/core/src/state/notebook/inner_state/note_tree/numbering.rs
+++ b/core/src/state/notebook/inner_state/note_tree/numbering.rs
@@ -73,7 +73,9 @@ pub async fn consume(
             reset_state(state);
             Ok(NotebookTransition::Inedible(event))
         }
-        _ => Err(Error::Todo("Notebook::consume".to_owned())),
+        _ => Err(Error::Todo(
+            "Notebook::NoteTree::Numbering::consume".to_owned(),
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure each `Error::Todo` message is unique
- reference inner notebook state in every message so logs are easier to trace

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684a60b154f4832aa6ce074874c61773