### PR TITLE
Add explicit AGENTS instructions to always run clippy and fmt in Codex workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Agent Instructions
+
+- Always run `cargo clippy --all-targets -- -D warnings` before committing and ensure it passes.
+- Run `cargo test` to verify all tests pass.
+- After clippy and tests succeed, run `cargo fmt` on the entire workspace before committing changes.


### PR DESCRIPTION
Background: When working with Codex and using AGENTS to automate tasks, it’s easy to forget to run cargo clippy and cargo fmt. This often leads to overlooked lint or formatting issues, which could have been caught earlier in the workflow.

This PR adds clear instructions to always run clippy and fmt as part of the AGENTS workflow for Codex. The goal is to ensure code quality and consistency by proactively catching formatting and lint errors before submitting or merging changes.

------
https://chatgpt.com/codex/tasks/task_e_684d0a87d3e0832a9cdb3fc0b03d664e