### PR TITLE
Fix low contrast breadcrumb text

### DIFF
--- a/tui/src/views/body/notebook/editor.rs
+++ b/tui/src/views/body/notebook/editor.rs
@@ -60,7 +60,7 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
                 format!("{name} ")
             };
 
-            breadcrumb.push(Span::raw(name).fg(THEME.warning_text).bg(color_a));
+            breadcrumb.push(Span::raw(name).fg(THEME.text).bg(color_a));
 
             if i < last_index {
                 breadcrumb.push(Span::raw("").fg(color_a).bg(color_b));


### PR DESCRIPTION
## Summary
- ensure breadcrumb text color matches theme text color for better readability

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d7fd27740832ab8be5428b21cb942