### PR TITLE
Remove unwraps in DB queries

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -3,6 +3,8 @@ pub use core_backend::CoreBackend;
 mod directory;
 mod log;
 mod note;
+mod util;
+pub(crate) use util::get_str;
 
 use {
     crate::{Result, schema::setup, task::Task, types::DirectoryId},

--- a/core/src/db/directory.rs
+++ b/core/src/db/directory.rs
@@ -1,9 +1,8 @@
 use {
-    super::{Db, Execute},
+    super::{Db, Execute, get_str},
     crate::{Error, Result, data::Directory, types::DirectoryId},
     async_recursion::async_recursion,
     gluesql::core::ast_builder::{col, function::now, table, text, uuid},
-    std::ops::Deref,
     uuid::Uuid,
 };
 
@@ -25,21 +24,9 @@ impl Db {
             .ok_or(Error::NotFound("directory not found".to_owned()))?;
 
         let directory = Directory {
-            id: payload
-                .get("id")
-                .map(Deref::deref)
-                .ok_or(Error::NotFound("id not found".to_owned()))?
-                .into(),
-            parent_id: payload
-                .get("parent_id")
-                .map(Deref::deref)
-                .ok_or(Error::NotFound("parent_id not found".to_owned()))?
-                .into(),
-            name: payload
-                .get("name")
-                .map(Deref::deref)
-                .ok_or(Error::NotFound("name not found".to_owned()))?
-                .into(),
+            id: get_str(&payload, "id")?,
+            parent_id: get_str(&payload, "parent_id")?,
+            name: get_str(&payload, "name")?,
         };
 
         Ok(directory)
@@ -56,17 +43,9 @@ impl Db {
             .ok_or(Error::NotFound("directories not found".to_owned()))?
             .map(|payload| {
                 Ok(Directory {
-                    id: payload
-                        .get("id")
-                        .map(Deref::deref)
-                        .ok_or(Error::NotFound("id not found".to_owned()))?
-                        .into(),
+                    id: get_str(&payload, "id")?,
                     parent_id: parent_id.clone(),
-                    name: payload
-                        .get("name")
-                        .map(Deref::deref)
-                        .ok_or(Error::NotFound("name not found".to_owned()))?
-                        .into(),
+                    name: get_str(&payload, "name")?,
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/db/note.rs
+++ b/core/src/db/note.rs
@@ -38,13 +38,23 @@ impl Db {
             .execute(&mut self.storage)
             .await?
             .select()
-            .unwrap()
-            .map(|payload| Note {
-                id: payload.get("id").map(Deref::deref).unwrap().into(),
-                directory_id: directory_id.clone(),
-                name: payload.get("name").map(Deref::deref).unwrap().into(),
+            .ok_or(Error::NotFound("notes not found".to_owned()))?
+            .map(|payload| {
+                Ok(Note {
+                    id: payload
+                        .get("id")
+                        .map(Deref::deref)
+                        .ok_or(Error::NotFound("id not found".to_owned()))?
+                        .into(),
+                    directory_id: directory_id.clone(),
+                    name: payload
+                        .get("name")
+                        .map(Deref::deref)
+                        .ok_or(Error::NotFound("name not found".to_owned()))?
+                        .into(),
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(notes)
     }

--- a/core/src/db/util.rs
+++ b/core/src/db/util.rs
@@ -1,0 +1,13 @@
+use {
+    crate::{Error, Result},
+    gluesql::prelude::Value,
+    std::{collections::HashMap, ops::Deref},
+};
+
+pub(crate) fn get_str(payload: &HashMap<&str, &Value>, key: &str) -> Result<String> {
+    payload
+        .get(key)
+        .map(Deref::deref)
+        .ok_or_else(|| Error::NotFound(format!("{key} not found")))
+        .map(Into::into)
+}

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -55,7 +55,7 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .execute(storage)
         .await?
         .select()
-        .unwrap()
+        .ok_or(Error::NotFound("schema_version not found".to_owned()))?
         .count()
         == 0;
 
@@ -75,7 +75,7 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .execute(storage)
         .await?
         .select()
-        .unwrap()
+        .ok_or(Error::NotFound("root directory not found".to_owned()))?
         .count()
         == 0;
 
@@ -95,9 +95,9 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .execute(storage)
         .await?
         .select()
-        .unwrap()
+        .ok_or(Error::NotFound("root directory not found".to_owned()))?
         .next()
-        .unwrap()
+        .ok_or(Error::NotFound("root directory not found".to_owned()))?
         .get("id")
         .map(Deref::deref)
         .map(Into::into)

--- a/core/tests/backend.rs
+++ b/core/tests/backend.rs
@@ -1,5 +1,7 @@
+use glues_core::Error;
 use glues_core::db::{CoreBackend, Db};
 use std::sync::mpsc::channel;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn memory_backend_operations() {
@@ -69,4 +71,15 @@ async fn memory_backend_operations() {
     db.log("test".to_owned(), "message".to_owned())
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn fetch_directory_not_found() {
+    let (tx, _rx) = channel();
+    let mut db = Db::memory(tx).await.unwrap();
+
+    let invalid_id = Uuid::now_v7().to_string();
+    let result = db.fetch_directory(invalid_id).await;
+
+    assert!(matches!(result, Err(Error::NotFound(_))));
 }


### PR DESCRIPTION
## Summary
- avoid unwraps when fetching directories/notes
- handle missing root directory in schema setup
- test directory lookup failure

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d7f3486f8832aadab589106590707