### PR TITLE
Refactor breadcrumb color semantics

### DIFF
--- a/tui/src/theme/dark.rs
+++ b/tui/src/theme/dark.rs
@@ -23,4 +23,5 @@ pub const DARK_THEME: Theme = Theme {
     inactive_bg: GRAY_DIM,
     crumb_a: GRAY_A,
     crumb_b: GRAY_B,
+    crumb_icon: YELLOW,
 };

--- a/tui/src/theme/forest.rs
+++ b/tui/src/theme/forest.rs
@@ -23,4 +23,5 @@ pub const FOREST_THEME: Theme = Theme {
     inactive_bg: Color::Rgb(50, 60, 50),
     crumb_a: Color::Rgb(30, 40, 30),
     crumb_b: Color::Rgb(45, 55, 45),
+    crumb_icon: Color::Rgb(255, 180, 20),
 };

--- a/tui/src/theme/light.rs
+++ b/tui/src/theme/light.rs
@@ -23,4 +23,5 @@ pub const LIGHT_THEME: Theme = Theme {
     inactive_bg: GRAY_LIGHT,
     crumb_a: GRAY_B,
     crumb_b: GRAY_A,
+    crumb_icon: YELLOW,
 };

--- a/tui/src/theme/midnight.rs
+++ b/tui/src/theme/midnight.rs
@@ -23,4 +23,5 @@ pub const MIDNIGHT_THEME: Theme = Theme {
     inactive_bg: Color::Rgb(30, 30, 50),
     crumb_a: Color::Rgb(35, 35, 55),
     crumb_b: Color::Rgb(55, 55, 75),
+    crumb_icon: Color::Rgb(255, 190, 0),
 };

--- a/tui/src/theme/mod.rs
+++ b/tui/src/theme/mod.rs
@@ -43,6 +43,8 @@ pub struct Theme {
     /// alternating breadcrumb background colors
     pub crumb_a: Color,
     pub crumb_b: Color,
+    /// symbol color for breadcrumbs and directory icons
+    pub crumb_icon: Color,
 }
 
 pub struct ThemeWrapper;

--- a/tui/src/theme/pastel.rs
+++ b/tui/src/theme/pastel.rs
@@ -23,4 +23,5 @@ pub const PASTEL_THEME: Theme = Theme {
     inactive_bg: Color::Rgb(221, 221, 221),
     crumb_a: Color::Rgb(240, 240, 240),
     crumb_b: Color::Rgb(224, 224, 224),
+    crumb_icon: Color::Rgb(255, 170, 0),
 };

--- a/tui/src/theme/sunrise.rs
+++ b/tui/src/theme/sunrise.rs
@@ -23,4 +23,5 @@ pub const SUNRISE_THEME: Theme = Theme {
     inactive_bg: Color::Rgb(240, 220, 200),
     crumb_a: Color::Rgb(250, 240, 230),
     crumb_b: Color::Rgb(240, 220, 210),
+    crumb_icon: Color::Rgb(255, 200, 0),
 };

--- a/tui/src/views/body/notebook/editor.rs
+++ b/tui/src/views/body/notebook/editor.rs
@@ -51,12 +51,12 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
             };
 
             let name = if i == 0 {
-                breadcrumb.push(Span::raw("  󰝰 ").fg(THEME.warning).bg(color_a));
+                breadcrumb.push(Span::raw("  󰝰 ").fg(THEME.crumb_icon).bg(color_a));
                 format!("{name} ")
             } else if i == last_index {
                 format!(" 󱇗 {name} ")
             } else {
-                breadcrumb.push(Span::raw(" 󰝰 ").fg(THEME.warning).bg(color_a));
+                breadcrumb.push(Span::raw(" 󰝰 ").fg(THEME.crumb_icon).bg(color_a));
                 format!("{name} ")
             };
 

--- a/tui/src/views/body/notebook/note_tree.rs
+++ b/tui/src/views/body/notebook/note_tree.rs
@@ -61,7 +61,7 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
                     let symbol = if *opened { OPEN_SYMBOL } else { CLOSED_SYMBOL };
                     Line::from(vec![
                         format!("{:pad$}", "").into(),
-                        Span::raw(symbol).fg(THEME.warning),
+                        Span::raw(symbol).fg(THEME.crumb_icon),
                         Span::raw(&directory.name),
                     ])
                 }


### PR DESCRIPTION
## Summary
- introduce `crumb_icon` color in theme
- use new color for breadcrumb and directory symbols

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684e5058e0ec832a82d1e4790b541334