### PR TITLE
Refactor highlight colors

### DIFF
--- a/tui/src/views/body/notebook/editor.rs
+++ b/tui/src/views/body/notebook/editor.rs
@@ -83,10 +83,8 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
             THEME.background,
         ),
         ContextState::EditorInsertMode => (
-            Span::raw(" INSERT ")
-                .fg(THEME.warning_text)
-                .bg(THEME.warning),
-            THEME.warning,
+            Span::raw(" INSERT ").fg(THEME.accent_text).bg(THEME.accent),
+            THEME.accent,
         ),
         ContextState::EditorVisualMode => (
             Span::raw(" VISUAL ").fg(THEME.error_text).bg(THEME.error),
@@ -108,10 +106,10 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
     ) {
         (_, true) => block.title_bottom(
             Line::from(vec![
-                Span::raw("").fg(THEME.warning).bg(THEME.background),
+                Span::raw("").fg(THEME.accent).bg(THEME.background),
                 Span::raw(" 󰔚 Saving... ")
-                    .fg(THEME.warning_text)
-                    .bg(THEME.warning),
+                    .fg(THEME.accent_text)
+                    .bg(THEME.accent),
             ])
             .right_aligned(),
         ),

--- a/tui/src/views/dialog/help.rs
+++ b/tui/src/views/dialog/help.rs
@@ -32,19 +32,19 @@ pub fn draw(frame: &mut Frame) {
     let message = vec![
         Line::from("Glues offers various storage options to suit your needs:"),
         Line::raw(""),
-        Line::from("Instant".fg(THEME.warning_text).bg(THEME.warning)),
+        Line::from("Instant".fg(THEME.accent_text).bg(THEME.accent)),
         Line::raw("Data is stored in memory and only persists while the app is running."),
         Line::raw(
             "This option is useful for testing or temporary notes as it is entirely volatile.",
         ),
         Line::raw(""),
-        Line::from("Local".fg(THEME.warning_text).bg(THEME.warning)),
+        Line::from("Local".fg(THEME.accent_text).bg(THEME.accent)),
         Line::raw("Notes are stored locally as separate files."),
         Line::raw(
             "This is the default option for users who prefer a simple, file-based approach without any remote synchronization.",
         ),
         Line::raw(""),
-        Line::from("Git".fg(THEME.warning_text).bg(THEME.warning)),
+        Line::from("Git".fg(THEME.accent_text).bg(THEME.accent)),
         Line::raw("Git storage requires three inputs: `path`, `remote`, and `branch`."),
         Line::raw(
             "The `path` should point to an existing local Git repository, similar to the file storage path.",
@@ -57,7 +57,7 @@ pub fn draw(frame: &mut Frame) {
             "When you modify notes or directories, Glues will automatically sync changes with the specified remote repository.",
         ),
         Line::raw(""),
-        Line::from("MongoDB".fg(THEME.warning_text).bg(THEME.warning)),
+        Line::from("MongoDB".fg(THEME.accent_text).bg(THEME.accent)),
         Line::raw(
             "MongoDB storage allows you to store your notes in a MongoDB database, providing a scalable and centralized solution for managing your notes.",
         ),
@@ -68,9 +68,9 @@ pub fn draw(frame: &mut Frame) {
         ),
         Line::raw(""),
         Line::from(vec![
-            "CSV".fg(THEME.warning_text).bg(THEME.warning),
+            "CSV".fg(THEME.accent_text).bg(THEME.accent),
             " or ".fg(THEME.inactive_text),
-            "JSON".fg(THEME.warning_text).bg(THEME.warning),
+            "JSON".fg(THEME.accent_text).bg(THEME.accent),
         ]),
         Line::raw(
             "These formats store notes as simple log files, ideal for quick data exports or reading logs.",

--- a/tui/src/views/dialog/keymap.rs
+++ b/tui/src/views/dialog/keymap.rs
@@ -74,8 +74,8 @@ pub fn draw(frame: &mut Frame, keymap: &[KeymapGroup]) {
         match row {
             Row::Title(title) => {
                 let line = Line::from(title.to_string())
-                    .fg(THEME.warning_text)
-                    .bg(THEME.warning);
+                    .fg(THEME.accent_text)
+                    .bg(THEME.accent);
                 let paragraph = Paragraph::new(line).alignment(Alignment::Left);
                 frame.render_widget(paragraph, *row_area);
             }

--- a/tui/src/views/dialog/vim_keymap.rs
+++ b/tui/src/views/dialog/vim_keymap.rs
@@ -15,7 +15,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::NormalIdle => (
             "VIM NORMAL MODE KEYMAP",
             vec![
-                Line::from("TO INSERT MODE".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("TO INSERT MODE".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[i] Go to insert mode"),
                 Line::raw("[I] Go to insert mode at the beginning of the line"),
                 Line::raw("[o] Insert a new line below and go to insert mode"),
@@ -25,7 +25,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[s] Delete character and go to insert mode"),
                 Line::raw("[S] Delete line and go to insert mode"),
                 Line::raw(""),
-                Line::from("TO OTHER MODES".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("TO OTHER MODES".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[c] Go to change mode (prepare to edit text)"),
                 Line::raw("[v] Go to visual mode (select text to edit or copy)"),
                 Line::raw("[g] Go to gateway mode (access extended commands)"),
@@ -34,7 +34,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[z] Go to scroll mode (adjust viewport)"),
                 Line::raw("[1-9] Go to numbering mode (repeat or extend actions with numbers)"),
                 Line::raw(""),
-                Line::from("MOVE CURSOR".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("MOVE CURSOR".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[h] Move cursor left"),
                 Line::raw("[j] Move cursor down"),
                 Line::raw("[k] Move cursor up"),
@@ -47,7 +47,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[^] Move cursor to the first non-blank character of the line"),
                 Line::raw("[G] Move cursor to the end of the file"),
                 Line::raw(""),
-                Line::from("EDIT TEXT".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("EDIT TEXT".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[~] Toggle the case of the current character"),
                 Line::raw("[x] Delete character under the cursor"),
                 Line::raw("[u] Undo the last change"),
@@ -59,24 +59,24 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
             vec![
                 Line::from(
                     "EXTENDING NUMBERING MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
-                Line::from("TO INSERT MODE".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("TO INSERT MODE".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[s] Delete specified number of characters and go to insert mode"),
                 Line::raw("[S] Delete the entire line and go to insert mode"),
                 Line::raw(""),
-                Line::from("TO OTHER MODES".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("TO OTHER MODES".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[c] Go to change mode with repeat count (prepare to edit text)"),
                 Line::raw("[y] Go to yank mode with repeat count (prepare to copy text)"),
                 Line::raw("[d] Go to delete mode with repeat count (prepare to delete text)"),
                 Line::raw(""),
                 Line::from(
                     "MOVE CURSOR AND RETURN TO NORMAL MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[h] Move cursor left by the specified number of times"),
                 Line::raw("[j] Move cursor down by the specified number of times"),
@@ -95,8 +95,8 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw(""),
                 Line::from(
                     "EDIT TEXT AND RETURN TO NORMAL MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[x] Delete specified number of characters and return to normal mode"),
             ],
@@ -104,17 +104,17 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::NormalDelete => (
             "VIM NORMAL MODE KEYMAP - DELETE",
             vec![
-                Line::from("TO NUMBERING MODE".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("TO NUMBERING MODE".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[1-9] Go to delete numbering mode"),
                 Line::raw(""),
                 Line::from(
                     "TO DELETE INSIDE MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[i] Go to delete inside mode"),
                 Line::raw(""),
-                Line::from("DELETE TEXT".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("DELETE TEXT".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[d] Delete the specified number of lines"),
                 Line::raw("[j] Delete the current and following lines"),
                 Line::raw("[k] Delete the current and previous lines"),
@@ -131,19 +131,19 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
             vec![
                 Line::from(
                     "EXTENDING NUMBERING MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
                 Line::from(
                     "TO DELETE INSIDE MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[i] Go to delete inside mode"),
                 Line::raw(""),
-                Line::from("DELETE TEXT".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("DELETE TEXT".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[d] Delete the specified number of lines"),
                 Line::raw("[j] Delete the current and following lines"),
                 Line::raw("[k] Delete the current and previous lines"),
@@ -159,15 +159,15 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
             vec![
                 Line::from(
                     "TO CHANGE INSIDE MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[i] Go to change inside mode"),
                 Line::raw(""),
                 Line::from(
                     "CHANGE TEXT AND GO TO INSERT MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[c] Delete the specified number of lines"),
                 Line::from(vec![
@@ -187,22 +187,22 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
             vec![
                 Line::from(
                     "EXTENDING NUMBERING MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
                 Line::from(
                     "TO CHANGE INSIDE MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[i] Go to change inside mode"),
                 Line::raw(""),
                 Line::from(
                     "CHANGE TEXT AND GO TO INSERT MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[c] Delete the specified number of lines"),
                 Line::from(vec![
@@ -219,7 +219,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::VisualIdle => (
             "VIM VISUAL MODE KEYMAP",
             vec![
-                Line::from("MOVE CURSOR".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("MOVE CURSOR".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[h] Move cursor left"),
                 Line::raw("[j] Move cursor down"),
                 Line::raw("[k] Move cursor up"),
@@ -232,21 +232,21 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[^] Move cursor to the first non-blank character of the line"),
                 Line::raw("[G] Move cursor to the end of the file"),
                 Line::raw(""),
-                Line::from("TO INSERT MODE".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("TO INSERT MODE".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::from(vec![
                     "[s] ".into(),
                     "or ".fg(THEME.inactive_text),
                     "[S] Substitute selected text and go to insert mode".into(),
                 ]),
                 Line::raw(""),
-                Line::from("TO EXTENDED MODES".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("TO EXTENDED MODES".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[g] Go to gateway mode for additional commands"),
                 Line::raw("[1-9] Specify repeat count for subsequent actions"),
                 Line::raw(""),
                 Line::from(
                     "EDIT TEXT AND RETURN TO NORMAL MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::from(vec![
                     "[d] ".into(),
@@ -262,12 +262,12 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
             vec![
                 Line::from(
                     "EXTENDING NUMBERING MODE"
-                        .fg(THEME.warning_text)
-                        .bg(THEME.warning),
+                        .fg(THEME.accent_text)
+                        .bg(THEME.accent),
                 ),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
-                Line::from("MOVE CURSOR".fg(THEME.warning_text).bg(THEME.warning)),
+                Line::from("MOVE CURSOR".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("[h] Move cursor left by the specified number of times"),
                 Line::raw("[j] Move cursor down by the specified number of times"),
                 Line::raw("[k] Move cursor up by the specified number of times"),


### PR DESCRIPTION
## Summary
- align highlight semantics with components by switching from `warning` color to `accent`
- update editor mode label and save indicator
- update help dialog list headings
- update keymap headers
- update vim keymap section labels

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e53b3feec832abf994353e0ee56f9