### PR TITLE
Document policy against mod.rs usage in AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 - Always run `cargo clippy --all-targets -- -D warnings` before committing and ensure it passes.
 - Run `cargo test` to verify all tests pass.
 - After clippy and tests succeed, run `cargo fmt` on the entire workspace before committing changes.
+- Use file-based module declarations; do **not** create `mod.rs` files.


### PR DESCRIPTION
## Summary
- document policy against `mod.rs` usage in AGENTS instructions

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_685697927e90832a95d68683624b362e