### PR TITLE
Open note after adding

### DIFF
--- a/tui/src/transitions/notebook/note_tree.rs
+++ b/tui/src/transitions/notebook/note_tree.rs
@@ -53,25 +53,33 @@ impl App {
                 directory_id: parent_id,
                 ..
             }) => {
-                self.glues
+                let transition = self
+                    .glues
                     .dispatch(NotebookEvent::OpenDirectory(parent_id.clone()).into())
                     .await
                     .log_unwrap();
+                self.handle_transition(transition).await;
+
                 let NotebookState { root, .. } = self.glues.state.get_inner().log_unwrap();
 
                 self.context.notebook.update_items(root);
                 self.context.notebook.select_item(&id);
 
-                self.glues
+                let transition = self
+                    .glues
                     .dispatch(NotebookEvent::OpenNote.into())
                     .await
                     .log_unwrap();
+                self.handle_transition(transition).await;
             }
             NoteTreeTransition::AddDirectory(Directory { id, parent_id, .. }) => {
-                self.glues
+                let transition = self
+                    .glues
                     .dispatch(NotebookEvent::OpenDirectory(parent_id.clone()).into())
                     .await
                     .log_unwrap();
+                self.handle_transition(transition).await;
+
                 let NotebookState { root, .. } = self.glues.state.get_inner().log_unwrap();
 
                 self.context.notebook.update_items(root);

--- a/tui/src/transitions/notebook/note_tree.rs
+++ b/tui/src/transitions/notebook/note_tree.rs
@@ -52,8 +52,22 @@ impl App {
                 id,
                 directory_id: parent_id,
                 ..
-            })
-            | NoteTreeTransition::AddDirectory(Directory { id, parent_id, .. }) => {
+            }) => {
+                self.glues
+                    .dispatch(NotebookEvent::OpenDirectory(parent_id.clone()).into())
+                    .await
+                    .log_unwrap();
+                let NotebookState { root, .. } = self.glues.state.get_inner().log_unwrap();
+
+                self.context.notebook.update_items(root);
+                self.context.notebook.select_item(&id);
+
+                self.glues
+                    .dispatch(NotebookEvent::OpenNote.into())
+                    .await
+                    .log_unwrap();
+            }
+            NoteTreeTransition::AddDirectory(Directory { id, parent_id, .. }) => {
                 self.glues
                     .dispatch(NotebookEvent::OpenDirectory(parent_id.clone()).into())
                     .await


### PR DESCRIPTION
## Summary
- dispatch `OpenNote` after adding a note so newly created notes open automatically

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6856a74bc28c832a843fa6504ae9696e