### PR TITLE
Add dynamic theme selection

### DIFF
--- a/tui/src/config.rs
+++ b/tui/src/config.rs
@@ -16,6 +16,7 @@ pub const LAST_GIT_REMOTE: &str = "last_git_remote";
 pub const LAST_GIT_BRANCH: &str = "last_git_branch";
 pub const LAST_MONGO_CONN_STR: &str = "last_mongo_conn_str";
 pub const LAST_MONGO_DB_NAME: &str = "last_mongo_db_name";
+pub const LAST_THEME: &str = "theme";
 
 const PATH: &str = ".glues/";
 
@@ -48,6 +49,7 @@ pub async fn init() {
         (LAST_GIT_BRANCH, "main"),
         (LAST_MONGO_CONN_STR, ""),
         (LAST_MONGO_DB_NAME, ""),
+        (LAST_THEME, "Dark"),
     ] {
         let _ = table("config")
             .insert()

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -50,16 +50,47 @@ enum ThemeArg {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    match cli.theme {
-        ThemeArg::Dark => theme::set_theme(theme::DARK_THEME),
-        ThemeArg::Light => theme::set_theme(theme::LIGHT_THEME),
-        ThemeArg::Pastel => theme::set_theme(theme::PASTEL_THEME),
-        ThemeArg::Sunrise => theme::set_theme(theme::SUNRISE_THEME),
-        ThemeArg::Midnight => theme::set_theme(theme::MIDNIGHT_THEME),
-        ThemeArg::Forest => theme::set_theme(theme::FOREST_THEME),
+    config::init().await;
+
+    if let Some(name) = config::get(config::LAST_THEME).await {
+        match name.as_str() {
+            "Dark" => theme::set_theme(theme::DARK_THEME),
+            "Light" => theme::set_theme(theme::LIGHT_THEME),
+            "Pastel" => theme::set_theme(theme::PASTEL_THEME),
+            "Sunrise" => theme::set_theme(theme::SUNRISE_THEME),
+            "Midnight" => theme::set_theme(theme::MIDNIGHT_THEME),
+            "Forest" => theme::set_theme(theme::FOREST_THEME),
+            _ => {}
+        }
     }
 
-    config::init().await;
+    match cli.theme {
+        ThemeArg::Dark => {
+            theme::set_theme(theme::DARK_THEME);
+            config::update(config::LAST_THEME, "Dark").await;
+        }
+        ThemeArg::Light => {
+            theme::set_theme(theme::LIGHT_THEME);
+            config::update(config::LAST_THEME, "Light").await;
+        }
+        ThemeArg::Pastel => {
+            theme::set_theme(theme::PASTEL_THEME);
+            config::update(config::LAST_THEME, "Pastel").await;
+        }
+        ThemeArg::Sunrise => {
+            theme::set_theme(theme::SUNRISE_THEME);
+            config::update(config::LAST_THEME, "Sunrise").await;
+        }
+        ThemeArg::Midnight => {
+            theme::set_theme(theme::MIDNIGHT_THEME);
+            config::update(config::LAST_THEME, "Midnight").await;
+        }
+        ThemeArg::Forest => {
+            theme::set_theme(theme::FOREST_THEME);
+            config::update(config::LAST_THEME, "Forest").await;
+        }
+    }
+
     logger::init().await;
     color_eyre::install()?;
 

--- a/tui/src/theme.rs
+++ b/tui/src/theme.rs
@@ -1,5 +1,6 @@
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
 use ratatui::style::Color;
+use std::sync::RwLock;
 
 pub mod dark;
 pub mod forest;
@@ -47,20 +48,12 @@ pub struct Theme {
     pub crumb_icon: Color,
 }
 
-pub struct ThemeWrapper;
+static THEME_CELL: Lazy<RwLock<Theme>> = Lazy::new(|| RwLock::new(DARK_THEME));
 
-static THEME_CELL: OnceCell<Theme> = OnceCell::new();
-
-impl std::ops::Deref for ThemeWrapper {
-    type Target = Theme;
-
-    fn deref(&self) -> &Self::Target {
-        THEME_CELL.get_or_init(|| DARK_THEME)
-    }
+pub fn current_theme() -> Theme {
+    *THEME_CELL.read().expect("theme read lock poisoned")
 }
 
-pub static THEME: ThemeWrapper = ThemeWrapper;
-
 pub fn set_theme(theme: Theme) {
-    let _ = THEME_CELL.set(theme);
+    *THEME_CELL.write().expect("theme write lock poisoned") = theme;
 }

--- a/tui/src/views/body/entry.rs
+++ b/tui/src/views/body/entry.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         context::{EntryContext, entry::MENU_ITEMS},
-        theme::THEME,
+        theme,
     },
     ratatui::{
         Frame,
@@ -13,7 +13,8 @@ use {
 };
 
 pub fn draw(frame: &mut Frame, area: Rect, context: &mut EntryContext) {
-    let background = Block::default().bg(THEME.background);
+    let t = theme::current_theme();
+    let background = Block::default().bg(t.background);
     frame.render_widget(background, area);
 
     let [area] = Layout::horizontal([Length(38)])
@@ -24,24 +25,24 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut EntryContext) {
         .areas(area);
 
     let title = BigText::builder()
-        .lines(vec!["Glues".fg(THEME.accent).into()])
+        .lines(vec!["Glues".fg(t.accent).into()])
         .build();
     let block = Block::bordered()
-        .fg(THEME.text)
+        .fg(t.text)
         .padding(Padding::new(2, 2, 1, 1))
         .title("Open Notes")
         .title_alignment(Alignment::Center);
 
     let items = MENU_ITEMS.into_iter().map(|name| {
         if name.ends_with("CSV") || name.ends_with("JSON") {
-            name.fg(THEME.inactive_text)
+            name.fg(t.inactive_text)
         } else {
-            name.fg(THEME.menu)
+            name.fg(t.menu)
         }
     });
     let list = List::new(items)
         .block(block)
-        .highlight_style(Style::new().fg(THEME.accent_text).bg(THEME.accent))
+        .highlight_style(Style::new().fg(t.accent_text).bg(t.accent))
         .highlight_symbol(" ")
         .highlight_spacing(HighlightSpacing::Always)
         .direction(ListDirection::TopToBottom);

--- a/tui/src/views/body/notebook/note_tree.rs
+++ b/tui/src/views/body/notebook/note_tree.rs
@@ -4,7 +4,7 @@ use {
             NotebookContext,
             notebook::{ContextState, TreeItem, TreeItemKind},
         },
-        theme::THEME,
+        theme,
     },
     ratatui::{
         Frame,
@@ -20,6 +20,7 @@ const OPEN_SYMBOL: &str = "󰝰 ";
 const NOTE_SYMBOL: &str = "󱇗 ";
 
 pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
+    let t = theme::current_theme();
     let note_tree_focused = matches!(
         context.state,
         ContextState::NoteTreeBrowsing
@@ -29,14 +30,14 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
     );
     let title = "[Browser]";
     let title = if note_tree_focused {
-        title.fg(THEME.highlight)
+        title.fg(t.highlight)
     } else {
-        title.fg(THEME.inactive_text)
+        title.fg(t.inactive_text)
     };
     let block = Block::new()
         .borders(Borders::RIGHT)
         .border_type(BorderType::QuadrantOutside)
-        .fg(THEME.hint)
+        .fg(t.hint)
         .title(title);
     let inner_area = block.inner(area);
 
@@ -61,15 +62,15 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
                     let symbol = if *opened { OPEN_SYMBOL } else { CLOSED_SYMBOL };
                     Line::from(vec![
                         format!("{:pad$}", "").into(),
-                        Span::raw(symbol).fg(THEME.crumb_icon),
+                        Span::raw(symbol).fg(t.crumb_icon),
                         Span::raw(&directory.name),
                     ])
                 }
             };
 
             match (selectable, target) {
-                (true, _) => line.fg(THEME.text),
-                (false, true) => line.fg(THEME.target),
+                (true, _) => line.fg(t.text),
+                (false, true) => line.fg(t.target),
                 (false, false) => line.dim(),
             }
         },
@@ -77,14 +78,14 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
 
     let highlight_style = Style::default()
         .bg(if note_tree_focused {
-            THEME.accent
+            t.accent
         } else {
-            THEME.surface
+            t.surface
         })
         .fg(if note_tree_focused {
-            THEME.accent_text
+            t.accent_text
         } else {
-            THEME.text
+            t.text
         });
 
     let list = List::new(tree_items)
@@ -93,6 +94,6 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
         .highlight_spacing(HighlightSpacing::Always)
         .direction(ListDirection::TopToBottom);
 
-    frame.render_widget(block.bg(THEME.background), area);
+    frame.render_widget(block.bg(t.background), area);
     frame.render_stateful_widget(list, inner_area, &mut context.tree_state);
 }

--- a/tui/src/views/dialog.rs
+++ b/tui/src/views/dialog.rs
@@ -6,6 +6,7 @@ mod help;
 mod keymap;
 mod note_actions;
 mod prompt;
+mod theme;
 mod vim_keymap;
 
 use {
@@ -39,6 +40,9 @@ pub fn draw(frame: &mut Frame, state: &State, context: &mut Context) {
         return;
     } else if context.prompt.is_some() {
         prompt::draw(frame, context);
+        return;
+    } else if context.theme_dialog {
+        theme::draw(frame, &mut context.entry);
         return;
     }
 

--- a/tui/src/views/dialog/alert.rs
+++ b/tui/src/views/dialog/alert.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{context::Context, logger::*, theme::THEME},
+    crate::{context::Context, logger::*, theme},
     ratatui::{
         Frame,
         layout::{Alignment, Constraint::Length, Flex, Layout},
@@ -10,14 +10,15 @@ use {
 };
 
 pub fn draw(frame: &mut Frame, context: &mut Context) {
+    let t = theme::current_theme();
     let [area] = Layout::horizontal([Length(45)])
         .flex(Flex::Center)
         .areas(frame.area());
     let [area] = Layout::vertical([Length(8)]).flex(Flex::Center).areas(area);
 
     let block = Block::bordered()
-        .fg(THEME.text)
-        .bg(THEME.surface)
+        .fg(t.text)
+        .bg(t.surface)
         .padding(Padding::new(2, 2, 1, 1))
         .title("Alert")
         .title_alignment(Alignment::Center);
@@ -37,7 +38,7 @@ pub fn draw(frame: &mut Frame, context: &mut Context) {
         .wrap(Wrap { trim: true })
         .style(Style::default())
         .alignment(Alignment::Left);
-    let control = Line::from("Press any key to close".fg(THEME.text_secondary)).centered();
+    let control = Line::from("Press any key to close".fg(t.text_secondary)).centered();
 
     frame.render_widget(Clear, area);
     frame.render_widget(block, area);

--- a/tui/src/views/dialog/confirm.rs
+++ b/tui/src/views/dialog/confirm.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{context::Context, logger::*, theme::THEME},
+    crate::{context::Context, logger::*, theme},
     ratatui::{
         Frame,
         layout::{Alignment, Constraint::Length, Flex, Layout},
@@ -9,14 +9,15 @@ use {
 };
 
 pub fn draw(frame: &mut Frame, context: &mut Context) {
+    let t = theme::current_theme();
     let [area] = Layout::horizontal([Length(40)])
         .flex(Flex::Center)
         .areas(frame.area());
     let [area] = Layout::vertical([Length(9)]).flex(Flex::Center).areas(area);
 
     let block = Block::bordered()
-        .bg(THEME.surface)
-        .fg(THEME.text)
+        .bg(t.surface)
+        .fg(t.text)
         .padding(Padding::new(2, 2, 1, 1))
         .title("Confirm")
         .title_alignment(Alignment::Center);
@@ -35,8 +36,8 @@ pub fn draw(frame: &mut Frame, context: &mut Context) {
         .alignment(Alignment::Left);
 
     let lines = vec![
-        "[y] Confirm".fg(THEME.text_secondary).into(),
-        "[n] Cancel".fg(THEME.text_secondary).into(),
+        "[y] Confirm".fg(t.text_secondary).into(),
+        "[n] Cancel".fg(t.text_secondary).into(),
     ];
     let control = Paragraph::new(lines)
         .wrap(Wrap { trim: true })

--- a/tui/src/views/dialog/editor_keymap.rs
+++ b/tui/src/views/dialog/editor_keymap.rs
@@ -1,5 +1,5 @@
 use {
-    crate::theme::THEME,
+    crate::theme,
     ratatui::{
         Frame,
         layout::{Alignment, Constraint::Length, Flex, Layout},
@@ -10,6 +10,7 @@ use {
 };
 
 pub fn draw(frame: &mut Frame) {
+    let t = theme::current_theme();
     let [area] = Layout::horizontal([Length(100)])
         .flex(Flex::Center)
         .areas(frame.area());
@@ -18,8 +19,8 @@ pub fn draw(frame: &mut Frame) {
         .areas(area);
 
     let block = Block::bordered()
-        .fg(THEME.text)
-        .bg(THEME.surface)
+        .fg(t.text)
+        .bg(t.surface)
         .padding(Padding::new(2, 2, 1, 1))
         .title("Editor Keymap")
         .title_alignment(Alignment::Center);
@@ -69,7 +70,7 @@ Thanks to tui-textarea
         .wrap(Wrap { trim: true })
         .style(Style::default())
         .alignment(Alignment::Left);
-    let control = Line::from("Press any key to close".fg(THEME.hint)).centered();
+    let control = Line::from("Press any key to close".fg(t.hint)).centered();
 
     frame.render_widget(Clear, area);
     frame.render_widget(block, area);

--- a/tui/src/views/dialog/help.rs
+++ b/tui/src/views/dialog/help.rs
@@ -1,5 +1,5 @@
 use {
-    crate::theme::THEME,
+    crate::theme,
     ratatui::{
         Frame,
         layout::{Alignment, Constraint::Length, Flex, Layout},
@@ -10,6 +10,7 @@ use {
 };
 
 pub fn draw(frame: &mut Frame) {
+    let t = theme::current_theme();
     let [area] = Layout::horizontal([Length(120)])
         .flex(Flex::Center)
         .areas(frame.area());
@@ -18,8 +19,8 @@ pub fn draw(frame: &mut Frame) {
         .areas(area);
 
     let block = Block::bordered()
-        .bg(THEME.surface)
-        .fg(THEME.text)
+        .bg(t.surface)
+        .fg(t.text)
         .padding(Padding::new(2, 2, 1, 1))
         .title("Help")
         .title_alignment(Alignment::Center);
@@ -32,19 +33,19 @@ pub fn draw(frame: &mut Frame) {
     let message = vec![
         Line::from("Glues offers various storage options to suit your needs:"),
         Line::raw(""),
-        Line::from("Instant".fg(THEME.accent_text).bg(THEME.accent)),
+        Line::from("Instant".fg(t.accent_text).bg(t.accent)),
         Line::raw("Data is stored in memory and only persists while the app is running."),
         Line::raw(
             "This option is useful for testing or temporary notes as it is entirely volatile.",
         ),
         Line::raw(""),
-        Line::from("Local".fg(THEME.accent_text).bg(THEME.accent)),
+        Line::from("Local".fg(t.accent_text).bg(t.accent)),
         Line::raw("Notes are stored locally as separate files."),
         Line::raw(
             "This is the default option for users who prefer a simple, file-based approach without any remote synchronization.",
         ),
         Line::raw(""),
-        Line::from("Git".fg(THEME.accent_text).bg(THEME.accent)),
+        Line::from("Git".fg(t.accent_text).bg(t.accent)),
         Line::raw("Git storage requires three inputs: `path`, `remote`, and `branch`."),
         Line::raw(
             "The `path` should point to an existing local Git repository, similar to the file storage path.",
@@ -57,7 +58,7 @@ pub fn draw(frame: &mut Frame) {
             "When you modify notes or directories, Glues will automatically sync changes with the specified remote repository.",
         ),
         Line::raw(""),
-        Line::from("MongoDB".fg(THEME.accent_text).bg(THEME.accent)),
+        Line::from("MongoDB".fg(t.accent_text).bg(t.accent)),
         Line::raw(
             "MongoDB storage allows you to store your notes in a MongoDB database, providing a scalable and centralized solution for managing your notes.",
         ),
@@ -68,9 +69,9 @@ pub fn draw(frame: &mut Frame) {
         ),
         Line::raw(""),
         Line::from(vec![
-            "CSV".fg(THEME.accent_text).bg(THEME.accent),
-            " or ".fg(THEME.inactive_text),
-            "JSON".fg(THEME.accent_text).bg(THEME.accent),
+            "CSV".fg(t.accent_text).bg(t.accent),
+            " or ".fg(t.inactive_text),
+            "JSON".fg(t.accent_text).bg(t.accent),
         ]),
         Line::raw(
             "These formats store notes as simple log files, ideal for quick data exports or reading logs.",
@@ -84,7 +85,7 @@ pub fn draw(frame: &mut Frame) {
         .wrap(Wrap { trim: true })
         .style(Style::default())
         .alignment(Alignment::Left);
-    let control = Line::from("Press any key to close".fg(THEME.text_secondary)).centered();
+    let control = Line::from("Press any key to close".fg(t.text_secondary)).centered();
 
     frame.render_widget(Clear, area);
     frame.render_widget(block, area);

--- a/tui/src/views/dialog/keymap.rs
+++ b/tui/src/views/dialog/keymap.rs
@@ -1,5 +1,5 @@
 use {
-    crate::theme::THEME,
+    crate::theme,
     glues_core::types::{KeymapGroup, KeymapItem},
     ratatui::{
         Frame,
@@ -19,6 +19,7 @@ const KEYMAP_WIDTH: u16 = 46;
 const KEY_WIDTH: u16 = 10;
 
 pub fn draw(frame: &mut Frame, keymap: &[KeymapGroup]) {
+    let t = theme::current_theme();
     let [area] = Layout::horizontal([Length(KEYMAP_WIDTH)])
         .flex(Flex::End)
         .areas(frame.area());
@@ -27,15 +28,15 @@ pub fn draw(frame: &mut Frame, keymap: &[KeymapGroup]) {
         .areas(area);
 
     let block = Block::default()
-        .fg(THEME.inactive_text)
-        .bg(THEME.panel)
+        .fg(t.inactive_text)
+        .bg(t.panel)
         .padding(Padding::new(2, 2, 1, 1))
         .title(
             Line::from(vec![
-                Span::raw("").fg(THEME.success).bg(THEME.panel),
+                Span::raw("").fg(t.success).bg(t.panel),
                 Span::raw(" [?] Hide keymap ")
-                    .fg(THEME.success_text)
-                    .bg(THEME.success),
+                    .fg(t.success_text)
+                    .bg(t.success),
             ])
             .right_aligned(),
         );
@@ -73,9 +74,7 @@ pub fn draw(frame: &mut Frame, keymap: &[KeymapGroup]) {
     for (row_area, row) in row_areas.iter().zip(rows) {
         match row {
             Row::Title(title) => {
-                let line = Line::from(title.to_string())
-                    .fg(THEME.accent_text)
-                    .bg(THEME.accent);
+                let line = Line::from(title.to_string()).fg(t.accent_text).bg(t.accent);
                 let paragraph = Paragraph::new(line).alignment(Alignment::Left);
                 frame.render_widget(paragraph, *row_area);
             }

--- a/tui/src/views/dialog/note_actions.rs
+++ b/tui/src/views/dialog/note_actions.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         context::{NotebookContext, notebook::NOTE_ACTIONS},
-        theme::THEME,
+        theme,
     },
     ratatui::{
         Frame,
@@ -12,20 +12,21 @@ use {
 };
 
 pub fn draw(frame: &mut Frame, context: &mut NotebookContext) {
+    let t = theme::current_theme();
     let [area] = Layout::horizontal([Length(28)])
         .flex(Flex::Center)
         .areas(frame.area());
     let [area] = Layout::vertical([Length(7)]).flex(Flex::Center).areas(area);
 
     let block = Block::bordered()
-        .bg(THEME.surface)
-        .fg(THEME.text)
+        .bg(t.surface)
+        .fg(t.text)
         .padding(Padding::new(2, 2, 1, 1))
         .title("Note Actions")
         .title_alignment(Alignment::Center);
     let list = List::new(NOTE_ACTIONS)
         .block(block)
-        .highlight_style(Style::new().fg(THEME.accent_text).bg(THEME.accent))
+        .highlight_style(Style::new().fg(t.accent_text).bg(t.accent))
         .highlight_symbol(" ")
         .highlight_spacing(HighlightSpacing::Always)
         .direction(ListDirection::TopToBottom);

--- a/tui/src/views/dialog/prompt.rs
+++ b/tui/src/views/dialog/prompt.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         context::{Context, ContextPrompt},
         logger::*,
-        theme::THEME,
+        theme,
     },
     ratatui::{
         Frame,
@@ -13,6 +13,7 @@ use {
 };
 
 pub fn draw(frame: &mut Frame, context: &mut Context) {
+    let t = theme::current_theme();
     let ContextPrompt {
         message, widget, ..
     } = context
@@ -29,8 +30,8 @@ pub fn draw(frame: &mut Frame, context: &mut Context) {
         .areas(area);
 
     let block = Block::bordered()
-        .bg(THEME.surface)
-        .fg(THEME.text)
+        .bg(t.surface)
+        .fg(t.text)
         .padding(Padding::new(2, 2, 1, 1))
         .title("Prompt")
         .title_alignment(Alignment::Center);
@@ -43,8 +44,8 @@ pub fn draw(frame: &mut Frame, context: &mut Context) {
         .alignment(Alignment::Left);
 
     let lines = vec![
-        "[Enter] Submit".fg(THEME.text_secondary).into(),
-        "[Esc] Cancel".fg(THEME.text_secondary).into(),
+        "[Enter] Submit".fg(t.text_secondary).into(),
+        "[Esc] Cancel".fg(t.text_secondary).into(),
     ];
     let control = Paragraph::new(lines)
         .wrap(Wrap { trim: true })

--- a/tui/src/views/dialog/theme.rs
+++ b/tui/src/views/dialog/theme.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        context::{NotebookContext, notebook::DIRECTORY_ACTIONS},
-        theme,
-    },
+    crate::{context::EntryContext, context::entry::THEMES, theme},
     ratatui::{
         Frame,
         layout::{Alignment, Constraint::Length, Flex, Layout},
@@ -11,7 +8,7 @@ use {
     },
 };
 
-pub fn draw(frame: &mut Frame, context: &mut NotebookContext) {
+pub fn draw(frame: &mut Frame, context: &mut EntryContext) {
     let t = theme::current_theme();
     let [area] = Layout::horizontal([Length(28)])
         .flex(Flex::Center)
@@ -22,9 +19,9 @@ pub fn draw(frame: &mut Frame, context: &mut NotebookContext) {
         .bg(t.surface)
         .fg(t.text)
         .padding(Padding::new(2, 2, 1, 1))
-        .title("Directory Actions")
+        .title("Theme")
         .title_alignment(Alignment::Center);
-    let list = List::new(DIRECTORY_ACTIONS)
+    let list = List::new(THEMES)
         .block(block)
         .highlight_style(Style::new().fg(t.accent_text).bg(t.accent))
         .highlight_symbol(" ")
@@ -32,5 +29,5 @@ pub fn draw(frame: &mut Frame, context: &mut NotebookContext) {
         .direction(ListDirection::TopToBottom);
 
     frame.render_widget(Clear, area);
-    frame.render_stateful_widget(list, area, &mut context.directory_actions_state);
+    frame.render_stateful_widget(list, area, &mut context.theme_state);
 }

--- a/tui/src/views/dialog/vim_keymap.rs
+++ b/tui/src/views/dialog/vim_keymap.rs
@@ -1,5 +1,5 @@
 use {
-    crate::theme::THEME,
+    crate::theme,
     glues_core::transition::VimKeymapKind,
     ratatui::{
         Frame,
@@ -11,11 +11,12 @@ use {
 };
 
 pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
+    let t = theme::current_theme();
     let (title, message) = match keymap_kind {
         VimKeymapKind::NormalIdle => (
             "VIM NORMAL MODE KEYMAP",
             vec![
-                Line::from("TO INSERT MODE".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("TO INSERT MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[i] Go to insert mode"),
                 Line::raw("[I] Go to insert mode at the beginning of the line"),
                 Line::raw("[o] Insert a new line below and go to insert mode"),
@@ -25,7 +26,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[s] Delete character and go to insert mode"),
                 Line::raw("[S] Delete line and go to insert mode"),
                 Line::raw(""),
-                Line::from("TO OTHER MODES".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("TO OTHER MODES".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[c] Go to change mode (prepare to edit text)"),
                 Line::raw("[v] Go to visual mode (select text to edit or copy)"),
                 Line::raw("[g] Go to gateway mode (access extended commands)"),
@@ -34,7 +35,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[z] Go to scroll mode (adjust viewport)"),
                 Line::raw("[1-9] Go to numbering mode (repeat or extend actions with numbers)"),
                 Line::raw(""),
-                Line::from("MOVE CURSOR".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("MOVE CURSOR".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[h] Move cursor left"),
                 Line::raw("[j] Move cursor down"),
                 Line::raw("[k] Move cursor up"),
@@ -47,7 +48,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[^] Move cursor to the first non-blank character of the line"),
                 Line::raw("[G] Move cursor to the end of the file"),
                 Line::raw(""),
-                Line::from("EDIT TEXT".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("EDIT TEXT".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[~] Toggle the case of the current character"),
                 Line::raw("[x] Delete character under the cursor"),
                 Line::raw("[u] Undo the last change"),
@@ -57,26 +58,22 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::NormalNumbering => (
             "VIM NORMAL MODE KEYMAP - NUMBERING",
             vec![
-                Line::from(
-                    "EXTENDING NUMBERING MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("EXTENDING NUMBERING MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
-                Line::from("TO INSERT MODE".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("TO INSERT MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[s] Delete specified number of characters and go to insert mode"),
                 Line::raw("[S] Delete the entire line and go to insert mode"),
                 Line::raw(""),
-                Line::from("TO OTHER MODES".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("TO OTHER MODES".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[c] Go to change mode with repeat count (prepare to edit text)"),
                 Line::raw("[y] Go to yank mode with repeat count (prepare to copy text)"),
                 Line::raw("[d] Go to delete mode with repeat count (prepare to delete text)"),
                 Line::raw(""),
                 Line::from(
                     "MOVE CURSOR AND RETURN TO NORMAL MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
+                        .fg(t.accent_text)
+                        .bg(t.accent),
                 ),
                 Line::raw("[h] Move cursor left by the specified number of times"),
                 Line::raw("[j] Move cursor down by the specified number of times"),
@@ -95,8 +92,8 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw(""),
                 Line::from(
                     "EDIT TEXT AND RETURN TO NORMAL MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
+                        .fg(t.accent_text)
+                        .bg(t.accent),
                 ),
                 Line::raw("[x] Delete specified number of characters and return to normal mode"),
             ],
@@ -104,17 +101,13 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::NormalDelete => (
             "VIM NORMAL MODE KEYMAP - DELETE",
             vec![
-                Line::from("TO NUMBERING MODE".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("TO NUMBERING MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[1-9] Go to delete numbering mode"),
                 Line::raw(""),
-                Line::from(
-                    "TO DELETE INSIDE MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("TO DELETE INSIDE MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[i] Go to delete inside mode"),
                 Line::raw(""),
-                Line::from("DELETE TEXT".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("DELETE TEXT".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[d] Delete the specified number of lines"),
                 Line::raw("[j] Delete the current and following lines"),
                 Line::raw("[k] Delete the current and previous lines"),
@@ -129,21 +122,13 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::NormalDelete2 => (
             "VIM NORMAL MODE KEYMAP - DELETE NUMBERING",
             vec![
-                Line::from(
-                    "EXTENDING NUMBERING MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("EXTENDING NUMBERING MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
-                Line::from(
-                    "TO DELETE INSIDE MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("TO DELETE INSIDE MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[i] Go to delete inside mode"),
                 Line::raw(""),
-                Line::from("DELETE TEXT".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("DELETE TEXT".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[d] Delete the specified number of lines"),
                 Line::raw("[j] Delete the current and following lines"),
                 Line::raw("[k] Delete the current and previous lines"),
@@ -157,22 +142,18 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::NormalChange => (
             "VIM NORMAL MODE KEYMAP - CHANGE",
             vec![
-                Line::from(
-                    "TO CHANGE INSIDE MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("TO CHANGE INSIDE MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[i] Go to change inside mode"),
                 Line::raw(""),
                 Line::from(
                     "CHANGE TEXT AND GO TO INSERT MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
+                        .fg(t.accent_text)
+                        .bg(t.accent),
                 ),
                 Line::raw("[c] Delete the specified number of lines"),
                 Line::from(vec![
                     "[e] ".into(),
-                    "or ".fg(THEME.inactive_text),
+                    "or ".fg(t.inactive_text),
                     "[w] Delete to the end of the word by the specified number of times".into(),
                 ]),
                 Line::raw(
@@ -185,29 +166,21 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::NormalChange2 => (
             "VIM NORMAL MODE KEYMAP - CHANGE NUMBERING",
             vec![
-                Line::from(
-                    "EXTENDING NUMBERING MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("EXTENDING NUMBERING MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
-                Line::from(
-                    "TO CHANGE INSIDE MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("TO CHANGE INSIDE MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[i] Go to change inside mode"),
                 Line::raw(""),
                 Line::from(
                     "CHANGE TEXT AND GO TO INSERT MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
+                        .fg(t.accent_text)
+                        .bg(t.accent),
                 ),
                 Line::raw("[c] Delete the specified number of lines"),
                 Line::from(vec![
                     "[e] ".into(),
-                    "or ".fg(THEME.inactive_text),
+                    "or ".fg(t.inactive_text),
                     "[w] Delete to the end of the word by the specified number of times".into(),
                 ]),
                 Line::raw(
@@ -219,7 +192,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::VisualIdle => (
             "VIM VISUAL MODE KEYMAP",
             vec![
-                Line::from("MOVE CURSOR".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("MOVE CURSOR".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[h] Move cursor left"),
                 Line::raw("[j] Move cursor down"),
                 Line::raw("[k] Move cursor up"),
@@ -232,25 +205,25 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
                 Line::raw("[^] Move cursor to the first non-blank character of the line"),
                 Line::raw("[G] Move cursor to the end of the file"),
                 Line::raw(""),
-                Line::from("TO INSERT MODE".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("TO INSERT MODE".fg(t.accent_text).bg(t.accent)),
                 Line::from(vec![
                     "[s] ".into(),
-                    "or ".fg(THEME.inactive_text),
+                    "or ".fg(t.inactive_text),
                     "[S] Substitute selected text and go to insert mode".into(),
                 ]),
                 Line::raw(""),
-                Line::from("TO EXTENDED MODES".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("TO EXTENDED MODES".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[g] Go to gateway mode for additional commands"),
                 Line::raw("[1-9] Specify repeat count for subsequent actions"),
                 Line::raw(""),
                 Line::from(
                     "EDIT TEXT AND RETURN TO NORMAL MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
+                        .fg(t.accent_text)
+                        .bg(t.accent),
                 ),
                 Line::from(vec![
                     "[d] ".into(),
-                    "or ".fg(THEME.inactive_text),
+                    "or ".fg(t.inactive_text),
                     "[x] Delete selected text".into(),
                 ]),
                 Line::raw("[y] Yank (copy) selected text"),
@@ -260,14 +233,10 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         VimKeymapKind::VisualNumbering => (
             "VIM VISUAL MODE KEYMAP - NUMBERING",
             vec![
-                Line::from(
-                    "EXTENDING NUMBERING MODE"
-                        .fg(THEME.accent_text)
-                        .bg(THEME.accent),
-                ),
+                Line::from("EXTENDING NUMBERING MODE".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[0-9] Append additional digits to extend the current command"),
                 Line::raw(""),
-                Line::from("MOVE CURSOR".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::from("MOVE CURSOR".fg(t.accent_text).bg(t.accent)),
                 Line::raw("[h] Move cursor left by the specified number of times"),
                 Line::raw("[j] Move cursor down by the specified number of times"),
                 Line::raw("[k] Move cursor up by the specified number of times"),
@@ -295,10 +264,10 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         .areas(area);
 
     let block = Block::bordered()
-        .fg(THEME.text)
-        .bg(THEME.surface)
+        .fg(t.text)
+        .bg(t.surface)
         .padding(Padding::new(2, 2, 1, 1))
-        .title(title.fg(THEME.success_text).bg(THEME.success))
+        .title(title.fg(t.success_text).bg(t.success))
         .title_alignment(Alignment::Center);
 
     let inner_area = block.inner(area);
@@ -309,7 +278,7 @@ pub fn draw(frame: &mut Frame, keymap_kind: VimKeymapKind) {
         .wrap(Wrap { trim: true })
         .style(Style::default())
         .alignment(Alignment::Left);
-    let control = Line::from("Press any key to close".fg(THEME.hint)).centered();
+    let control = Line::from("Press any key to close".fg(t.hint)).centered();
 
     frame.render_widget(Clear, area);
     frame.render_widget(block, area);

--- a/tui/src/views/statusbar.rs
+++ b/tui/src/views/statusbar.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         context::{NotebookContext, notebook::ContextState},
         logger::*,
-        theme::THEME,
+        theme,
     },
     glues_core::state::State,
     ratatui::{
@@ -17,6 +17,7 @@ use {
 };
 
 pub fn draw(frame: &mut Frame, area: Rect, state: &State, context: &NotebookContext) {
+    let t = theme::current_theme();
     let description = format!(" {}", state.describe().log_unwrap());
     let insert_mode = matches!(context.state, ContextState::EditorInsertMode);
     let [desc_area, keymap_area] =
@@ -24,22 +25,20 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &State, context: &NotebookCont
             .areas(area);
 
     frame.render_widget(
-        Text::raw(description)
-            .fg(THEME.inactive_text)
-            .bg(THEME.panel),
+        Text::raw(description).fg(t.inactive_text).bg(t.panel),
         desc_area,
     );
 
     frame.render_widget(
         Line::from(vec![
-            Span::raw("").fg(THEME.success).bg(THEME.panel),
+            Span::raw("").fg(t.success).bg(t.panel),
             Span::raw(if insert_mode {
                 " [Ctrl+h] Show keymap "
             } else {
                 " [?] Show keymap "
             })
-            .fg(THEME.success_text)
-            .bg(THEME.success),
+            .fg(t.success_text)
+            .bg(t.success),
         ]),
         keymap_area,
     );


### PR DESCRIPTION
## Summary
- allow theme to be changed at runtime using a RwLock-backed global
- add theme selection option on the entry screen
- persist selected theme in config
- show theme list dialog and handle new TuiActions

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6856acba13c4832a8640a073c79e0fac