### PR TITLE
Implement ordering for notes and directories

### DIFF
--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -18,6 +18,7 @@ pub trait CoreBackend {
         directory_id: DirectoryId,
         parent_id: DirectoryId,
     ) -> Result<()>;
+    async fn reorder_directory(&mut self, directory_id: DirectoryId, order: i64) -> Result<()>;
     async fn rename_directory(&mut self, directory_id: DirectoryId, name: String) -> Result<()>;
 
     async fn fetch_notes(&mut self, directory_id: DirectoryId) -> Result<Vec<Note>>;
@@ -27,6 +28,7 @@ pub trait CoreBackend {
     async fn rename_note(&mut self, note_id: NoteId, name: String) -> Result<()>;
     async fn update_note_content(&mut self, note_id: NoteId, content: String) -> Result<()>;
     async fn move_note(&mut self, note_id: NoteId, directory_id: DirectoryId) -> Result<()>;
+    async fn reorder_note(&mut self, note_id: NoteId, order: i64) -> Result<()>;
 
     async fn log(&mut self, category: String, message: String) -> Result<()>;
 }

--- a/core/src/backend/local/core_backend.rs
+++ b/core/src/backend/local/core_backend.rs
@@ -38,6 +38,10 @@ impl CoreBackend for Db {
         Db::move_directory(self, directory_id, parent_id).await
     }
 
+    async fn reorder_directory(&mut self, directory_id: DirectoryId, order: i64) -> Result<()> {
+        Db::reorder_directory(self, directory_id, order).await
+    }
+
     async fn rename_directory(&mut self, directory_id: DirectoryId, name: String) -> Result<()> {
         Db::rename_directory(self, directory_id, name).await
     }
@@ -68,6 +72,10 @@ impl CoreBackend for Db {
 
     async fn move_note(&mut self, note_id: NoteId, directory_id: DirectoryId) -> Result<()> {
         Db::move_note(self, note_id, directory_id).await
+    }
+
+    async fn reorder_note(&mut self, note_id: NoteId, order: i64) -> Result<()> {
+        Db::reorder_note(self, note_id, order).await
     }
 
     async fn log(&mut self, category: String, message: String) -> Result<()> {

--- a/core/src/backend/proxy/client.rs
+++ b/core/src/backend/proxy/client.rs
@@ -109,6 +109,20 @@ impl CoreBackend for ProxyClient {
         }
     }
 
+    async fn reorder_directory(&mut self, directory_id: DirectoryId, order: i64) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::ReorderDirectory {
+                directory_id,
+                order,
+            })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
+        }
+    }
+
     async fn rename_directory(&mut self, directory_id: DirectoryId, name: String) -> Result<()> {
         match self
             .rpc(ProxyRequest::RenameDirectory { directory_id, name })
@@ -180,6 +194,17 @@ impl CoreBackend for ProxyClient {
                 note_id,
                 directory_id,
             })
+            .await?
+        {
+            ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),
+            ProxyResponse::Err(e) => Err(Error::Proxy(e)),
+            _ => Err(Error::InvalidResponse("invalid response".to_owned())),
+        }
+    }
+
+    async fn reorder_note(&mut self, note_id: NoteId, order: i64) -> Result<()> {
+        match self
+            .rpc(ProxyRequest::ReorderNote { note_id, order })
             .await?
         {
             ProxyResponse::Ok(ResultPayload::Unit) => Ok(()),

--- a/core/src/backend/proxy/request.rs
+++ b/core/src/backend/proxy/request.rs
@@ -22,6 +22,10 @@ pub enum ProxyRequest {
         directory_id: DirectoryId,
         parent_id: DirectoryId,
     },
+    ReorderDirectory {
+        directory_id: DirectoryId,
+        order: i64,
+    },
     RenameDirectory {
         directory_id: DirectoryId,
         name: String,
@@ -50,6 +54,10 @@ pub enum ProxyRequest {
     MoveNote {
         note_id: NoteId,
         directory_id: DirectoryId,
+    },
+    ReorderNote {
+        note_id: NoteId,
+        order: i64,
     },
     Log {
         category: String,

--- a/core/src/backend/proxy/server.rs
+++ b/core/src/backend/proxy/server.rs
@@ -45,6 +45,13 @@ where
                 Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
                 Err(e) => ProxyResponse::Err(e.to_string()),
             },
+            ReorderDirectory {
+                directory_id,
+                order,
+            } => match self.db.reorder_directory(directory_id, order).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
             RenameDirectory { directory_id, name } => {
                 match self.db.rename_directory(directory_id, name).await {
                     Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
@@ -81,6 +88,10 @@ where
                 note_id,
                 directory_id,
             } => match self.db.move_note(note_id, directory_id).await {
+                Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
+                Err(e) => ProxyResponse::Err(e.to_string()),
+            },
+            ReorderNote { note_id, order } => match self.db.reorder_note(note_id, order).await {
                 Ok(()) => ProxyResponse::Ok(ResultPayload::Unit),
                 Err(e) => ProxyResponse::Err(e.to_string()),
             },

--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -6,6 +6,7 @@ pub struct Note {
     pub id: NoteId,
     pub directory_id: DirectoryId,
     pub name: String,
+    pub order: i64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -13,4 +14,5 @@ pub struct Directory {
     pub id: DirectoryId,
     pub parent_id: DirectoryId,
     pub name: String,
+    pub order: i64,
 }

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -60,6 +60,11 @@ pub enum NotebookEvent {
     AddNote(String),
     AddDirectory(String),
 
+    ReorderNoteUp,
+    ReorderNoteDown,
+    ReorderDirectoryUp,
+    ReorderDirectoryDown,
+
     MoveNote(DirectoryId),
     MoveDirectory(DirectoryId),
 

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -4,7 +4,7 @@ use {
         backend::local::{Execute, Storage},
         types::DirectoryId,
     },
-    gluesql::core::ast_builder::{col, table, text},
+    gluesql::core::ast_builder::{col, num, table, text},
     std::ops::Deref,
 };
 
@@ -32,6 +32,7 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .add_column("id UUID PRIMARY KEY DEFAULT GENERATE_UUID()")
         .add_column("parent_id UUID NULL")
         .add_column("name TEXT NOT NULL")
+        .add_column("order INTEGER NOT NULL")
         .add_column("created_at TIMESTAMP NOT NULL DEFAULT NOW()")
         .add_column("updated_at TIMESTAMP NOT NULL DEFAULT NOW()")
         .execute(storage)
@@ -42,6 +43,7 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .add_column("id UUID PRIMARY KEY")
         .add_column("name TEXT NOT NULL")
         .add_column("directory_id UUID NOT NULL")
+        .add_column("order INTEGER NOT NULL")
         .add_column("created_at TIMESTAMP NOT NULL DEFAULT NOW()")
         .add_column("updated_at TIMESTAMP NOT NULL DEFAULT NOW()")
         .add_column("content TEXT NOT NULL DEFAULT ''")
@@ -82,8 +84,8 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
     if root_not_exists {
         table("Directory")
             .insert()
-            .columns("name")
-            .values(vec![vec![text("Notes")]])
+            .columns(vec!["name", "order"])
+            .values(vec![vec![text("Notes"), num(0)]])
             .execute(storage)
             .await?;
     }

--- a/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
@@ -71,6 +71,8 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Key(KeyEvent::CapK) => Ok(NotebookTransition::NoteTree(
             NoteTreeTransition::SelectPrevDirectory,
         )),
+        Key(KeyEvent::CapH) => directory::reorder(db, state, true).await,
+        Key(KeyEvent::CapL) => directory::reorder(db, state, false).await,
         Key(KeyEvent::M) => {
             let directory = state.get_selected_directory()?.clone();
 
@@ -125,6 +127,8 @@ pub fn keymap(state: &NotebookState) -> Vec<KeymapGroup> {
         KeymapItem::new(">", "Expand width"),
         KeymapItem::new("<", "Shrink width"),
         KeymapItem::new("Space", "Move directory"),
+        KeymapItem::new("H", "Move up"),
+        KeymapItem::new("L", "Move down"),
         KeymapItem::new("m", "Show more actions"),
     ];
 

--- a/core/src/state/notebook/inner_state/note_tree/note_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_selected.rs
@@ -52,6 +52,8 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Key(KeyEvent::CapK) => Ok(NotebookTransition::NoteTree(
             NoteTreeTransition::SelectPrevDirectory,
         )),
+        Key(KeyEvent::CapH) => note::reorder(db, state, true).await,
+        Key(KeyEvent::CapL) => note::reorder(db, state, false).await,
         Key(KeyEvent::M) => {
             let note = state.get_selected_note()?.clone();
 
@@ -115,6 +117,8 @@ pub fn keymap(state: &NotebookState) -> Vec<KeymapGroup> {
         KeymapItem::new("h", "Close parent directory"),
         KeymapItem::new("g", "Enter gateway mode"),
         KeymapItem::new("Space", "Move note"),
+        KeymapItem::new("H", "Move up"),
+        KeymapItem::new("L", "Move down"),
         KeymapItem::new("m", "Show more actions"),
     ];
 

--- a/core/src/transition.rs
+++ b/core/src/transition.rs
@@ -82,6 +82,9 @@ pub enum NoteTreeTransition {
     AddNote(Note),
     AddDirectory(Directory),
 
+    ReorderNote(Note),
+    ReorderDirectory(Directory),
+
     ShowNoteActionsDialog(Note),
     ShowDirectoryActionsDialog(Directory),
 

--- a/core/tests/backend.rs
+++ b/core/tests/backend.rs
@@ -16,11 +16,19 @@ async fn memory_backend_operations() {
         .await
         .unwrap();
     assert_eq!(dir.name, "Work");
+    assert_eq!(dir.order, 0);
+
+    let dir2 = db
+        .add_directory(root_id.clone(), "Life".to_owned())
+        .await
+        .unwrap();
+    assert_eq!(dir2.order, 1);
 
     // fetch directories
     let dirs = db.fetch_directories(root_id.clone()).await.unwrap();
-    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs.len(), 2);
     assert_eq!(dirs[0].name, "Work");
+    assert_eq!(dirs[1].name, "Life");
 
     // add note
     let note = db
@@ -28,11 +36,19 @@ async fn memory_backend_operations() {
         .await
         .unwrap();
     assert_eq!(note.name, "Todo");
+    assert_eq!(note.order, 0);
+
+    let note2 = db
+        .add_note(dir.id.clone(), "Plan".to_owned())
+        .await
+        .unwrap();
+    assert_eq!(note2.order, 1);
 
     // fetch notes
     let notes = db.fetch_notes(dir.id.clone()).await.unwrap();
-    assert_eq!(notes.len(), 1);
+    assert_eq!(notes.len(), 2);
     assert_eq!(notes[0].name, "Todo");
+    assert_eq!(notes[1].name, "Plan");
 
     // update note content
     db.update_note_content(note.id.clone(), "hello".to_owned())
@@ -47,6 +63,7 @@ async fn memory_backend_operations() {
         .unwrap();
     let notes = db.fetch_notes(dir.id.clone()).await.unwrap();
     assert_eq!(notes[0].name, "Hello");
+    assert_eq!(notes[1].name, "Plan");
 
     // move note to root
     db.move_note(note.id.clone(), root_id.clone())
@@ -54,6 +71,7 @@ async fn memory_backend_operations() {
         .unwrap();
     let notes_root = db.fetch_notes(root_id.clone()).await.unwrap();
     assert_eq!(notes_root.len(), 1);
+    assert_eq!(notes_root[0].name, "Hello");
 
     // remove note
     db.remove_note(note.id.clone()).await.unwrap();
@@ -62,6 +80,7 @@ async fn memory_backend_operations() {
 
     // remove directory
     db.remove_directory(dir.id.clone()).await.unwrap();
+    db.remove_directory(dir2.id.clone()).await.unwrap();
     let dirs = db.fetch_directories(root_id.clone()).await.unwrap();
     assert!(dirs.is_empty());
 

--- a/core/tests/proxy.rs
+++ b/core/tests/proxy.rs
@@ -53,20 +53,36 @@ async fn proxy_backend_operations() {
         .await
         .unwrap();
     assert_eq!(dir.name, "Work");
+    assert_eq!(dir.order, 0);
+
+    let dir2 = client
+        .add_directory(root_id.clone(), "Life".to_owned())
+        .await
+        .unwrap();
+    assert_eq!(dir2.order, 1);
 
     let dirs = client.fetch_directories(root_id.clone()).await.unwrap();
-    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs.len(), 2);
     assert_eq!(dirs[0].name, "Work");
+    assert_eq!(dirs[1].name, "Life");
 
     let note = client
         .add_note(dir.id.clone(), "Todo".to_owned())
         .await
         .unwrap();
     assert_eq!(note.name, "Todo");
+    assert_eq!(note.order, 0);
+
+    let note2 = client
+        .add_note(dir.id.clone(), "Plan".to_owned())
+        .await
+        .unwrap();
+    assert_eq!(note2.order, 1);
 
     let notes = client.fetch_notes(dir.id.clone()).await.unwrap();
-    assert_eq!(notes.len(), 1);
+    assert_eq!(notes.len(), 2);
     assert_eq!(notes[0].name, "Todo");
+    assert_eq!(notes[1].name, "Plan");
 
     client
         .update_note_content(note.id.clone(), "hello".to_owned())
@@ -81,6 +97,7 @@ async fn proxy_backend_operations() {
         .unwrap();
     let notes = client.fetch_notes(dir.id.clone()).await.unwrap();
     assert_eq!(notes[0].name, "Hello");
+    assert_eq!(notes[1].name, "Plan");
 
     client
         .move_note(note.id.clone(), root_id.clone())
@@ -88,12 +105,14 @@ async fn proxy_backend_operations() {
         .unwrap();
     let notes_root = client.fetch_notes(root_id.clone()).await.unwrap();
     assert_eq!(notes_root.len(), 1);
+    assert_eq!(notes_root[0].name, "Hello");
 
     client.remove_note(note.id.clone()).await.unwrap();
     let notes_root = client.fetch_notes(root_id.clone()).await.unwrap();
     assert!(notes_root.is_empty());
 
     client.remove_directory(dir.id.clone()).await.unwrap();
+    client.remove_directory(dir2.id.clone()).await.unwrap();
     let dirs = client.fetch_directories(root_id.clone()).await.unwrap();
     assert!(dirs.is_empty());
 

--- a/tui/src/transitions/notebook/note_tree.rs
+++ b/tui/src/transitions/notebook/note_tree.rs
@@ -48,6 +48,14 @@ impl App {
                 self.context.notebook.update_items(root);
                 self.context.notebook.tabs = tabs.clone();
             }
+            NoteTreeTransition::ReorderDirectory(directory) => {
+                self.context.notebook.update_items(root);
+                self.context.notebook.select_item(&directory.id);
+            }
+            NoteTreeTransition::ReorderNote(note) => {
+                self.context.notebook.update_items(root);
+                self.context.notebook.select_item(&note.id);
+            }
             NoteTreeTransition::AddNote(Note {
                 id,
                 directory_id: parent_id,


### PR DESCRIPTION
## Summary
- add TUI keybindings to reorder notes and directories
- refresh the note tree after reordering
- keep selected item highlighted after move

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6856a5b04e64832a95ce45ca82a011dc