### PR TITLE
Update AGENTS.md - branch naming rule to allow only lowercase, dashes, and slashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Run `cargo test` to verify all tests pass.
 - After clippy and tests succeed, run `cargo fmt` on the entire workspace before committing changes.
 - Use file-based module declarations; do **not** create `mod.rs` files.
+- Branch names may contain only lowercase `a`-`z`, dashes (`-`), and slashes (`/`).


### PR DESCRIPTION
## Summary
- simplify branch naming instructions so only lowercase letters, dashes, and slashes are allowed

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68579c05738c832a8f77c5e8f0cf53e4