### PR TITLE
Update Rust toolchain to 1.88

### DIFF
--- a/core/src/state/notebook/consume/directory.rs
+++ b/core/src/state/notebook/consume/directory.rs
@@ -203,8 +203,7 @@ pub async fn add<B: CoreBackend + ?Sized>(
         .root
         .find_mut(&parent_id)
         .ok_or(Error::NotFound(format!(
-            "[directory::add] parent directory not found: {}",
-            parent_id
+            "[directory::add] parent directory not found: {parent_id}"
         )))?;
 
     if let DirectoryItem {

--- a/core/tests/proxy.rs
+++ b/core/tests/proxy.rs
@@ -40,7 +40,7 @@ async fn proxy_backend_operations() {
         }
     });
 
-    let mut client = ProxyClient::connect(format!("http://{}", addr))
+    let mut client = ProxyClient::connect(format!("http://{addr}"))
         .await
         .unwrap();
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.88"
 components = ["rustfmt", "clippy"]

--- a/tui/src/context/notebook.rs
+++ b/tui/src/context/notebook.rs
@@ -189,7 +189,7 @@ impl NotebookContext {
             .selected()
             .and_then(|i| self.tree_items.get(i))
             .map(|item| item.id());
-        let is_move_mode = matches!(self.state, ContextState::MoveMode { .. });
+        let is_move_mode = matches!(self.state, ContextState::MoveMode);
         let selectable = !is_move_mode || (selectable && Some(&directory_item.directory.id) != id);
 
         let mut items = vec![TreeItem {

--- a/tui/src/views/body/notebook/editor.rs
+++ b/tui/src/views/body/notebook/editor.rs
@@ -114,12 +114,7 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
             .right_aligned(),
         ),
         (Some((log, _)), false) => block.title_bottom(
-            Line::from(
-                format!(" {} ", log)
-                    .fg(THEME.success_text)
-                    .bg(THEME.success),
-            )
-            .right_aligned(),
+            Line::from(format!(" {log} ").fg(THEME.success_text).bg(THEME.success)).right_aligned(),
         ),
         (None, false) => block,
     }


### PR DESCRIPTION
## Summary
- update Rust toolchain to 1.88
- resolve new clippy warnings

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686bb9ebac84832ab6b4b4a48e008b27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated string formatting style in error messages and URL construction for improved readability.
  * Simplified and condensed code for UI element styling without changing appearance or behavior.
  * Corrected pattern matching to reflect updated enum variant structure.

* **Chores**
  * Upgraded the Rust toolchain version from 1.85 to 1.88.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->