### PR TITLE
chore: update Rust toolchain to 1.89

### DIFF
--- a/core/src/state/notebook/directory_item.rs
+++ b/core/src/state/notebook/directory_item.rs
@@ -83,7 +83,7 @@ impl DirectoryItem {
         Some(&directory_item.directory)
     }
 
-    pub(crate) fn tree_items(&self, depth: usize) -> Vec<TreeItem> {
+    pub(crate) fn tree_items(&self, depth: usize) -> Vec<TreeItem<'_>> {
         let mut items = vec![TreeItem {
             id: &self.directory.id,
             name: &self.directory.name,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"
 components = ["rustfmt", "clippy"]

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -86,10 +86,13 @@ impl App {
 
     async fn run(mut self, mut terminal: DefaultTerminal) -> Result<()> {
         loop {
-            if let Some((_, created_at)) = self.context.last_log {
-                if created_at.elapsed().log_unwrap().as_secs() > 5 {
-                    self.context.last_log = None;
-                }
+            if self
+                .context
+                .last_log
+                .as_ref()
+                .is_some_and(|(_, created_at)| created_at.elapsed().log_unwrap().as_secs() > 5)
+            {
+                self.context.last_log = None;
             }
 
             terminal.draw(|frame| self.draw(frame))?;


### PR DESCRIPTION
## Summary
- update rust-toolchain to version 1.89
- adjust code for new clippy lints

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8518aa6d0832aa3bde589ef47a5c0