### PR TITLE
Use find_map instead of filter_map().next() when searching directories

### DIFF
--- a/core/src/state/notebook/directory_item.rs
+++ b/core/src/state/notebook/directory_item.rs
@@ -25,8 +25,7 @@ impl DirectoryItem {
             .as_ref()?
             .directories
             .iter()
-            .filter_map(|item| item.find(id))
-            .next()
+            .find_map(|item| item.find(id))
     }
 
     pub fn find_mut(&mut self, id: &DirectoryId) -> Option<&mut DirectoryItem> {
@@ -38,8 +37,7 @@ impl DirectoryItem {
             .as_mut()?
             .directories
             .iter_mut()
-            .filter_map(|item| item.find_mut(id))
-            .next()
+            .find_map(|item| item.find_mut(id))
     }
 
     pub fn rename_directory(&mut self, target: &Directory) -> Option<()> {


### PR DESCRIPTION
## Summary
- use `find_map` instead of `filter_map().next()` when searching directories

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b914f03074832a8addf509d681af9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal search logic in notebook directory traversal for clearer intent and minor efficiency gains.
  * No user-visible behavior changes; existing notebooks and operations continue to work as before.
  * No changes to settings, APIs, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->