### PR TITLE
Remove unused async qualifiers in core

### DIFF
--- a/core/src/backend/local.rs
+++ b/core/src/backend/local.rs
@@ -115,7 +115,7 @@ impl Db {
         })
     }
 
-    pub async fn pull(&mut self) -> Result<()> {
+    pub fn pull(&mut self) -> Result<()> {
         if let Storage::Git(glue) = &mut self.storage {
             glue.storage.pull()?;
         }

--- a/core/src/glues.rs
+++ b/core/src/glues.rs
@@ -24,8 +24,14 @@ pub struct Glues {
     pub transition_queue: Arc<Mutex<VecDeque<Transition>>>,
 }
 
+impl Default for Glues {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Glues {
-    pub async fn new() -> Self {
+    pub fn new() -> Self {
         let transition_queue = Arc::new(Mutex::new(VecDeque::new()));
         let (task_tx, task_rx) = channel();
         let task_handle = handle_tasks(task_rx, &transition_queue);

--- a/core/src/state/notebook/consume/note.rs
+++ b/core/src/state/notebook/consume/note.rs
@@ -176,7 +176,7 @@ pub async fn open<B: CoreBackend + ?Sized>(
     }))
 }
 
-pub async fn view(state: &mut NotebookState) -> Result<NotebookTransition> {
+pub fn view(state: &mut NotebookState) -> Result<NotebookTransition> {
     let note = state.get_editing()?.clone();
 
     state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);

--- a/core/src/state/notebook/inner_state.rs
+++ b/core/src/state/notebook/inner_state.rs
@@ -38,10 +38,8 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         EditingNormalMode(vim_state) => {
             editing_normal_mode::consume(db, state, *vim_state, event).await
         }
-        EditingVisualMode(vim_state) => {
-            editing_visual_mode::consume(db, state, *vim_state, event).await
-        }
-        EditingInsertMode => editing_insert_mode::consume(db, state, event).await,
+        EditingVisualMode(vim_state) => editing_visual_mode::consume(db, state, *vim_state, event),
+        EditingInsertMode => editing_insert_mode::consume(db, state, event),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_insert_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_insert_mode.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume<B: CoreBackend + ?Sized>(
+pub fn consume<B: CoreBackend + ?Sized>(
     _db: &mut B,
     state: &mut NotebookState,
     event: Event,
@@ -14,7 +14,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
     use NotebookEvent::*;
 
     match event {
-        Key(KeyEvent::Esc) | Notebook(ViewNote) => note::view(state).await,
+        Key(KeyEvent::Esc) | Notebook(ViewNote) => note::view(state),
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
         _ => Err(Error::Todo(
             "Notebook::EditingInsertMode::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode.rs
@@ -46,20 +46,20 @@ pub async fn consume<B: CoreBackend + ?Sized>(
     event: Event,
 ) -> Result<NotebookTransition> {
     match vim_state {
-        VimNormalState::Idle => idle::consume(state, event).await,
+        VimNormalState::Idle => idle::consume(state, event),
         VimNormalState::Toggle => toggle::consume(db, state, event).await,
-        VimNormalState::ToggleTabClose => toggle_tab_close::consume(state, event).await,
-        VimNormalState::Numbering(n) => numbering::consume(state, n, event).await,
-        VimNormalState::Gateway => gateway::consume(state, event).await,
-        VimNormalState::Yank(n) => yank::consume(state, n, event).await,
-        VimNormalState::Yank2(n1, n2) => yank2::consume(state, n1, n2, event).await,
-        VimNormalState::Delete(n) => delete::consume(state, n, event).await,
-        VimNormalState::Delete2(n1, n2) => delete2::consume(state, n1, n2, event).await,
-        VimNormalState::DeleteInside(n) => delete_inside::consume(state, n, event).await,
-        VimNormalState::Change(n) => change::consume(state, n, event).await,
-        VimNormalState::Change2(n1, n2) => change2::consume(state, n1, n2, event).await,
-        VimNormalState::ChangeInside(n) => change_inside::consume(state, n, event).await,
-        VimNormalState::Scroll => scroll::consume(state, event).await,
+        VimNormalState::ToggleTabClose => toggle_tab_close::consume(state, event),
+        VimNormalState::Numbering(n) => numbering::consume(state, n, event),
+        VimNormalState::Gateway => gateway::consume(state, event),
+        VimNormalState::Yank(n) => yank::consume(state, n, event),
+        VimNormalState::Yank2(n1, n2) => yank2::consume(state, n1, n2, event),
+        VimNormalState::Delete(n) => delete::consume(state, n, event),
+        VimNormalState::Delete2(n1, n2) => delete2::consume(state, n1, n2, event),
+        VimNormalState::DeleteInside(n) => delete_inside::consume(state, n, event),
+        VimNormalState::Change(n) => change::consume(state, n, event),
+        VimNormalState::Change2(n1, n2) => change2::consume(state, n1, n2, event),
+        VimNormalState::ChangeInside(n) => change_inside::consume(state, n, event),
+        VimNormalState::Scroll => scroll::consume(state, event),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change.rs
@@ -5,11 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -53,7 +49,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Change::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change2.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
+pub fn consume(
     state: &mut NotebookState,
     n1: usize,
     n2: usize,
@@ -60,7 +60,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Change2::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/change_inside.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/change_inside.rs
@@ -5,11 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -22,7 +18,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::ChangeInside::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete.rs
@@ -5,11 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -79,7 +75,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Delete::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete2.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
+pub fn consume(
     state: &mut NotebookState,
     n1: usize,
     n2: usize,
@@ -75,7 +75,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Delete2::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/delete_inside.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/delete_inside.rs
@@ -5,11 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -22,7 +18,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::DeleteInside::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/gateway.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/gateway.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -24,7 +24,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Gateway::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
@@ -7,7 +7,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
     use NotebookEvent as NE;

--- a/core/src/state/notebook/inner_state/editing_normal_mode/numbering.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/numbering.rs
@@ -6,11 +6,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -102,7 +98,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Numbering::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/scroll.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/scroll.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -28,7 +28,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Scroll::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/toggle.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/toggle.rs
@@ -39,7 +39,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Toggle::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/toggle_tab_close.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/toggle_tab_close.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -34,7 +34,7 @@ pub async fn consume(state: &mut NotebookState, event: Event) -> Result<Notebook
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::ToggleTabClose::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/yank.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/yank.rs
@@ -5,11 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NormalModeTransition::*;
 
@@ -33,7 +29,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Yank::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_normal_mode/yank2.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/yank2.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(
+pub fn consume(
     state: &mut NotebookState,
     n1: usize,
     n2: usize,
@@ -34,7 +34,7 @@ pub async fn consume(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(super::VimNormalState::Idle);
 
-            super::idle::consume(state, event).await
+            super::idle::consume(state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingNormalMode::Yank2::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_visual_mode.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode.rs
@@ -17,16 +17,16 @@ pub enum VimVisualState {
     Numbering(usize),
 }
 
-pub async fn consume<B: CoreBackend + ?Sized>(
+pub fn consume<B: CoreBackend + ?Sized>(
     db: &mut B,
     state: &mut NotebookState,
     vim_state: VimVisualState,
     event: Event,
 ) -> Result<NotebookTransition> {
     match vim_state {
-        VimVisualState::Idle => idle::consume(db, state, event).await,
-        VimVisualState::Gateway => gateway::consume(db, state, event).await,
-        VimVisualState::Numbering(n) => numbering::consume(db, state, n, event).await,
+        VimVisualState::Idle => idle::consume(db, state, event),
+        VimVisualState::Gateway => gateway::consume(db, state, event),
+        VimVisualState::Numbering(n) => numbering::consume(db, state, n, event),
     }
 }
 

--- a/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/gateway.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume<B: CoreBackend + ?Sized>(
+pub fn consume<B: CoreBackend + ?Sized>(
     db: &mut B,
     state: &mut NotebookState,
     event: Event,
@@ -28,7 +28,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            super::idle::consume(db, state, event).await
+            super::idle::consume(db, state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingVisualMode::Gateway::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/idle.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume<B: CoreBackend + ?Sized>(
+pub fn consume<B: CoreBackend + ?Sized>(
     _db: &mut B,
     state: &mut NotebookState,
     event: Event,

--- a/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
+++ b/core/src/state/notebook/inner_state/editing_visual_mode/numbering.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume<B: CoreBackend + ?Sized>(
+pub fn consume<B: CoreBackend + ?Sized>(
     db: &mut B,
     state: &mut NotebookState,
     n: usize,
@@ -76,7 +76,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         event @ Key(_) => {
             state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
-            super::idle::consume(db, state, event).await
+            super::idle::consume(db, state, event)
         }
         _ => Err(Error::Todo(
             "Notebook::EditingVisualMode::Numbering::consume".to_owned(),

--- a/core/src/state/notebook/inner_state/note_tree.rs
+++ b/core/src/state/notebook/inner_state/note_tree.rs
@@ -35,8 +35,8 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         DirectorySelected => directory_selected::consume(db, state, event).await,
         NoteMoreActions => note_more_actions::consume(db, state, event).await,
         DirectoryMoreActions => directory_more_actions::consume(db, state, event).await,
-        Numbering(n) => numbering::consume(state, n, event).await,
-        GatewayMode => gateway::consume(state, event).await,
+        Numbering(n) => numbering::consume(state, n, event),
+        GatewayMode => gateway::consume(state, event),
         MoveMode => move_mode::consume(db, state, event).await,
     }
 }

--- a/core/src/state/notebook/inner_state/note_tree/gateway.rs
+++ b/core/src/state/notebook/inner_state/note_tree/gateway.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{KeymapGroup, KeymapItem},
 };
 
-pub async fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransition> {
     use Event::*;
 
     match event {

--- a/core/src/state/notebook/inner_state/note_tree/numbering.rs
+++ b/core/src/state/notebook/inner_state/note_tree/numbering.rs
@@ -8,11 +8,7 @@ use {
     },
 };
 
-pub async fn consume(
-    state: &mut NotebookState,
-    n: usize,
-    event: Event,
-) -> Result<NotebookTransition> {
+pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<NotebookTransition> {
     use Event::*;
     use NotebookEvent::*;
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
     log!("Hello");
 
     let terminal = ratatui::init();
-    let app_result = App::new().await.run(terminal).await;
+    let app_result = App::new().run(terminal).await;
     ratatui::restore();
     app_result
 }
@@ -77,8 +77,8 @@ struct App {
 }
 
 impl App {
-    async fn new() -> Self {
-        let glues = Glues::new().await;
+    fn new() -> Self {
+        let glues = Glues::new();
         let context = Context::default();
 
         Self { glues, context }


### PR DESCRIPTION
## Summary
- drop unnecessary async from backend and state helpers
- implement `Default` for `Glues` and make constructors synchronous
- adjust call sites after removing async

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b9146928d4832a9b432a5a7cca4223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a default initialization path for the core controller.
- Refactor
  - Simplified initialization and interaction handling by removing unnecessary async usage across the app and editing modes.
- Performance
  - Faster startup and more responsive notebook interactions (mode switches, scrolling, yank/delete actions).
- Stability
  - Reduced asynchronous boundaries to minimize potential race conditions during navigation and editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->