### PR TITLE
Remove unnecessary Result wrappers from notebook consumers

### DIFF
--- a/core/src/state/notebook/consume/directory.rs
+++ b/core/src/state/notebook/consume/directory.rs
@@ -100,23 +100,18 @@ pub fn close(state: &mut NotebookState, directory: Directory) -> Result<Notebook
     ))
 }
 
-pub fn show_actions_dialog(
-    state: &mut NotebookState,
-    directory: Directory,
-) -> Result<NotebookTransition> {
+pub fn show_actions_dialog(state: &mut NotebookState, directory: Directory) -> NotebookTransition {
     state.selected = SelectedItem::Directory(directory.clone());
     state.inner_state = InnerState::NoteTree(NoteTreeState::DirectoryMoreActions);
 
-    Ok(NotebookTransition::NoteTree(
-        NoteTreeTransition::ShowDirectoryActionsDialog(directory),
-    ))
+    NotebookTransition::NoteTree(NoteTreeTransition::ShowDirectoryActionsDialog(directory))
 }
 
-pub fn select(state: &mut NotebookState, directory: Directory) -> Result<NotebookTransition> {
+pub fn select(state: &mut NotebookState, directory: Directory) -> NotebookTransition {
     state.selected = SelectedItem::Directory(directory);
     state.inner_state = InnerState::NoteTree(NoteTreeState::DirectorySelected);
 
-    Ok(NotebookTransition::None)
+    NotebookTransition::None
 }
 
 pub async fn rename<B: CoreBackend + ?Sized>(

--- a/core/src/state/notebook/consume/note.rs
+++ b/core/src/state/notebook/consume/note.rs
@@ -14,19 +14,17 @@ use {
     std::cmp::min,
 };
 
-pub fn show_actions_dialog(state: &mut NotebookState, note: Note) -> Result<NotebookTransition> {
+pub fn show_actions_dialog(state: &mut NotebookState, note: Note) -> NotebookTransition {
     state.inner_state = InnerState::NoteTree(NoteTreeState::NoteMoreActions);
 
-    Ok(NotebookTransition::NoteTree(
-        NoteTreeTransition::ShowNoteActionsDialog(note),
-    ))
+    NotebookTransition::NoteTree(NoteTreeTransition::ShowNoteActionsDialog(note))
 }
 
-pub fn select(state: &mut NotebookState, note: Note) -> Result<NotebookTransition> {
+pub fn select(state: &mut NotebookState, note: Note) -> NotebookTransition {
     state.selected = SelectedItem::Note(note);
     state.inner_state = InnerState::NoteTree(NoteTreeState::NoteSelected);
 
-    Ok(NotebookTransition::None)
+    NotebookTransition::None
 }
 
 pub async fn rename<B: CoreBackend + ?Sized>(

--- a/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
+++ b/core/src/state/notebook/inner_state/editing_normal_mode/idle.rs
@@ -13,8 +13,8 @@ pub fn consume(state: &mut NotebookState, event: Event) -> Result<NotebookTransi
     use NotebookEvent as NE;
 
     match event {
-        Notebook(NE::SelectNote(note)) => note::select(state, note),
-        Notebook(NE::SelectDirectory(directory)) => directory::select(state, directory),
+        Notebook(NE::SelectNote(note)) => Ok(note::select(state, note)),
+        Notebook(NE::SelectDirectory(directory)) => Ok(directory::select(state, directory)),
         Key(KeyEvent::Tab) => {
             state.inner_state = InnerState::NoteTree(NoteTreeState::NoteSelected);
 

--- a/core/src/state/notebook/inner_state/note_tree/directory_more_actions.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_more_actions.rs
@@ -17,7 +17,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Notebook(CloseDirectoryActionsDialog) => {
             let directory = state.get_selected_directory()?.clone();
 
-            directory::select(state, directory)
+            Ok(directory::select(state, directory))
         }
         Notebook(RenameDirectory(new_name)) => {
             let directory = state.get_selected_directory()?.clone();
@@ -42,7 +42,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Cancel => {
             let directory = state.get_selected_directory()?.clone();
 
-            directory::select(state, directory)
+            Ok(directory::select(state, directory))
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
         _ => Err(Error::Todo(

--- a/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
@@ -74,7 +74,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Key(KeyEvent::M) => {
             let directory = state.get_selected_directory()?.clone();
 
-            directory::show_actions_dialog(state, directory)
+            Ok(directory::show_actions_dialog(state, directory))
         }
         Key(KeyEvent::Space) => {
             state.inner_state = InnerState::NoteTree(NoteTreeState::MoveMode);
@@ -83,8 +83,8 @@ pub async fn consume<B: CoreBackend + ?Sized>(
                 MoveModeTransition::Enter,
             )))
         }
-        Notebook(SelectNote(note)) => note::select(state, note),
-        Notebook(SelectDirectory(directory)) => directory::select(state, directory),
+        Notebook(SelectNote(note)) => Ok(note::select(state, note)),
+        Notebook(SelectDirectory(directory)) => Ok(directory::select(state, directory)),
         Key(KeyEvent::Num(n)) => {
             state.inner_state = InnerState::NoteTree(NoteTreeState::Numbering(n.into()));
 

--- a/core/src/state/notebook/inner_state/note_tree/note_more_actions.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_more_actions.rs
@@ -17,7 +17,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Notebook(CloseNoteActionsDialog) => {
             let note = state.get_selected_note()?.clone();
 
-            note::select(state, note)
+            Ok(note::select(state, note))
         }
         Notebook(RenameNote(new_name)) => {
             let note = state.get_selected_note()?.clone();
@@ -32,7 +32,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Cancel => {
             let note = state.get_selected_note()?.clone();
 
-            note::select(state, note.clone())
+            Ok(note::select(state, note.clone()))
         }
         event @ Key(_) => Ok(NotebookTransition::Inedible(event)),
         _ => Err(Error::Todo(

--- a/core/src/state/notebook/inner_state/note_tree/note_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_selected.rs
@@ -55,7 +55,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
         Key(KeyEvent::M) => {
             let note = state.get_selected_note()?.clone();
 
-            note::show_actions_dialog(state, note)
+            Ok(note::show_actions_dialog(state, note))
         }
         Key(KeyEvent::Space) => {
             state.inner_state = InnerState::NoteTree(NoteTreeState::MoveMode);
@@ -64,8 +64,8 @@ pub async fn consume<B: CoreBackend + ?Sized>(
                 MoveModeTransition::Enter,
             )))
         }
-        Notebook(SelectNote(note)) => note::select(state, note),
-        Notebook(SelectDirectory(directory)) => directory::select(state, directory),
+        Notebook(SelectNote(note)) => Ok(note::select(state, note)),
+        Notebook(SelectDirectory(directory)) => Ok(directory::select(state, directory)),
         Key(KeyEvent::L | KeyEvent::Enter) | Notebook(OpenNote) => {
             let note = state.get_selected_note()?.clone();
 

--- a/core/src/state/notebook/inner_state/note_tree/numbering.rs
+++ b/core/src/state/notebook/inner_state/note_tree/numbering.rs
@@ -25,8 +25,8 @@ pub fn consume(state: &mut NotebookState, n: usize, event: Event) -> Result<Note
     };
 
     match event {
-        Notebook(SelectNote(note)) => note::select(state, note),
-        Notebook(SelectDirectory(directory)) => directory::select(state, directory),
+        Notebook(SelectNote(note)) => Ok(note::select(state, note)),
+        Notebook(SelectDirectory(directory)) => Ok(directory::select(state, directory)),
         Key(KeyEvent::Num(n2)) => {
             let step = n2 + n.saturating_mul(10);
             state.inner_state = InnerState::NoteTree(NoteTreeState::Numbering(step));


### PR DESCRIPTION
## Summary
- return plain `NotebookTransition` from notebook directory/note helpers
- update call sites to wrap in `Ok` where necessary

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6da83690832a9503e9f8d0b38514