### PR TITLE
Use clone_from when updating note name and directory IDs

### DIFF
--- a/core/src/state/notebook/consume/note.rs
+++ b/core/src/state/notebook/consume/note.rs
@@ -48,7 +48,7 @@ pub async fn rename<B: CoreBackend + ?Sized>(
     ))?;
 
     for tab in state.tabs.iter_mut().filter(|tab| tab.note.id == note.id) {
-        tab.note.name = note.name.clone();
+        tab.note.name.clone_from(&note.name);
     }
 
     state.selected = SelectedItem::Note(note.clone());
@@ -164,7 +164,7 @@ pub async fn open<B: CoreBackend + ?Sized>(
         };
         state.tabs.push(tab.clone());
         state.tab_index = Some(state.tabs.len() - 1);
-    };
+    }
 
     state.inner_state = InnerState::EditingNormalMode(VimNormalState::Idle);
 
@@ -205,11 +205,11 @@ pub async fn move_note<B: CoreBackend + ?Sized>(
     directory_id: DirectoryId,
 ) -> Result<NotebookTransition> {
     let mut note = state.get_selected_note()?.clone();
-    note.directory_id = directory_id.clone();
+    note.directory_id.clone_from(&directory_id);
 
     state.tabs.iter_mut().for_each(|tab| {
         if tab.note.id == note.id {
-            tab.note.directory_id = directory_id.clone();
+            tab.note.directory_id.clone_from(&directory_id);
         }
     });
 


### PR DESCRIPTION
## Summary
- use `clone_from` when updating note name and directory IDs
- remove stray semicolon after opening a note tab

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6db4c53c832ab3259c6da0074aa9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Optimized in-memory updates when renaming notes and moving notes between directories to reduce allocations and improve efficiency across open tabs.
  - Performance and behavior remain unchanged for end-users; operations may feel slightly smoother under heavy usage.

- Style
  - Minor formatting cleanup with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->