### PR TITLE
Remove unnecessary clone in keymap dialog

### DIFF
--- a/tui/src/views/dialog/keymap.rs
+++ b/tui/src/views/dialog/keymap.rs
@@ -68,7 +68,7 @@ pub fn draw(frame: &mut Frame, keymap: &[KeymapGroup]) {
     let row_areas = Layout::vertical(row_constraints).split(inner_area);
 
     frame.render_widget(Clear, area);
-    frame.render_widget(block.clone(), area);
+    frame.render_widget(block, area);
 
     for (row_area, row) in row_areas.iter().zip(rows) {
         match row {


### PR DESCRIPTION
## Summary
- avoid cloning `Block` when rendering keymap dialog

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba72ffa668832a9d5f220afbbe17cb