### PR TITLE
Avoid cloning note names when rendering notebook tabs

### DIFF
--- a/tui/src/views/body/notebook/editor.rs
+++ b/tui/src/views/body/notebook/editor.rs
@@ -21,7 +21,7 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
     let (title, mut bottom_left) = if let Some(tab_index) = context.notebook.tab_index {
         let mut title = vec![];
         for (i, tab) in context.notebook.tabs.iter().enumerate() {
-            let name = format!(" {NOTE_SYMBOL}{} ", tab.note.name.clone());
+            let name = format!(" {NOTE_SYMBOL}{} ", tab.note.name);
             let name = if i == tab_index {
                 if context.notebook.state.is_editor() {
                     name.fg(THEME.accent_text).bg(THEME.accent)


### PR DESCRIPTION
## Summary
- avoid cloning note names when rendering notebook tabs

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68ba765c91cc832a88ca734449458e55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined tab label rendering in the notebook editor to eliminate redundant allocations, improving efficiency without changing appearance or behavior.
  * Slightly reduces memory overhead and can make tab switching and navigation feel more responsive, especially with many tabs or larger notebooks.
  * Internal cleanup only; no impact on user settings or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->