### PR TITLE
Handle both H and left arrow in a single Key pattern for note tree states

### DIFF
--- a/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/directory_selected.rs
@@ -43,7 +43,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             directory::close(state, directory)
         }
-        Key(KeyEvent::H) | Key(KeyEvent::Left) => {
+        Key(KeyEvent::H | KeyEvent::Left) => {
             let directory = state.get_selected_directory()?;
             if state.root.directory.id == directory.id {
                 return Ok(NotebookTransition::None);

--- a/core/src/state/notebook/inner_state/note_tree/note_selected.rs
+++ b/core/src/state/notebook/inner_state/note_tree/note_selected.rs
@@ -31,7 +31,7 @@ pub async fn consume<B: CoreBackend + ?Sized>(
 
             directory::close(state, directory)
         }
-        Key(KeyEvent::H) | Key(KeyEvent::Left) => {
+        Key(KeyEvent::H | KeyEvent::Left) => {
             let directory_id = &state.get_selected_note()?.directory_id;
             let directory_item = state.root.find(directory_id).ok_or(Error::NotFound(
                 "[Key::H] failed to find parent directory".to_owned(),


### PR DESCRIPTION
## Summary
- handle both `H` and left arrow in a single `Key` pattern for note tree states

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo clippy -p glues-core --all-targets -- -D warnings -W clippy::pedantic` *(fails: numerous existing pedantic warnings in glues-core)*

------
https://chatgpt.com/codex/tasks/task_e_68ba71981cb0832abd8e41e56bebcf2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of keyboard navigation when a directory or note is selected, unifying equivalent key inputs for moving to a parent folder or collapsing a directory.
  * No changes to shortcuts or behavior; navigation works exactly as before.
  * Improves consistency and maintainability of navigation logic, supporting future enhancements without user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->