### PR TITLE
Add structured in-process integration tests for Entry and Notebook flows

### DIFF
--- a/tui/tests/entry_inproc.rs
+++ b/tui/tests/entry_inproc.rs
@@ -1,0 +1,144 @@
+#![cfg(feature = "test-utils")]
+
+use color_eyre::Result;
+use ratatui::{
+    Terminal,
+    backend::TestBackend,
+    crossterm::event::{Event as Input, KeyCode, KeyEvent, KeyModifiers},
+};
+
+use glues::{App, config, logger};
+
+fn buffer_to_lines(term: &Terminal<TestBackend>) -> Vec<String> {
+    let buf = term.backend().buffer().clone();
+    let area = buf.area();
+    let mut lines = Vec::with_capacity(area.height as usize);
+    for y in 0..area.height {
+        let mut line = String::new();
+        for x in 0..area.width {
+            line.push_str(buf[(x, y)].symbol());
+        }
+        lines.push(line);
+    }
+    lines
+}
+
+async fn setup() -> Result<(App, Terminal<TestBackend>)> {
+    // ensure logger/config have a writable HOME directory
+    let cwd = std::env::current_dir()?;
+    unsafe {
+        std::env::set_var("HOME", &cwd);
+    }
+    config::init().await;
+    logger::init().await;
+
+    let backend = TestBackend::new(120, 40);
+    let term = Terminal::new(backend)?;
+    let app = App::new();
+
+    Ok((app, term))
+}
+
+#[tokio::test]
+async fn entry_nav_enter_opens_instant_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+
+    // initial draw (home)
+    app.draw_once_on(&mut term)?;
+
+    // move down then up, then Enter to open Instant via selection
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('k'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    )))
+    .await;
+
+    // draw and assert notebook content is visible (e.g., sample note)
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains("Sample Note"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn entry_quit_with_q_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    app.draw_once_on(&mut term)?;
+
+    let quit = app
+        .handle_input(Input::Key(KeyEvent::new(
+            KeyCode::Char('q'),
+            KeyModifiers::NONE,
+        )))
+        .await;
+    assert!(quit);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn entry_keymap_toggle_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    app.draw_once_on(&mut term)?;
+
+    // show keymap
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('?'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains(" [?] Hide keymap "));
+
+    // hide keymap
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('?'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(!buf.contains(" [?] Hide keymap "));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn entry_help_overlay_open_close_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    app.draw_once_on(&mut term)?;
+
+    // open help (currently bound to 'a')
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('a'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains("Press any key to close"));
+
+    // any key closes help
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('x'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(!buf.contains("Press any key to close"));
+
+    Ok(())
+}

--- a/tui/tests/notebook_inproc.rs
+++ b/tui/tests/notebook_inproc.rs
@@ -1,0 +1,277 @@
+#![cfg(feature = "test-utils")]
+
+use color_eyre::Result;
+use ratatui::{
+    Terminal,
+    backend::TestBackend,
+    crossterm::event::{Event as Input, KeyCode, KeyEvent, KeyModifiers},
+};
+
+use glues::{App, config, logger};
+
+fn buffer_to_lines(term: &Terminal<TestBackend>) -> Vec<String> {
+    let buf = term.backend().buffer().clone();
+    let area = buf.area();
+    let mut lines = Vec::with_capacity(area.height as usize);
+    for y in 0..area.height {
+        let mut line = String::new();
+        for x in 0..area.width {
+            line.push_str(buf[(x, y)].symbol());
+        }
+        lines.push(line);
+    }
+    lines
+}
+
+async fn setup() -> Result<(App, Terminal<TestBackend>)> {
+    // ensure logger/config have a writable HOME directory
+    let cwd = std::env::current_dir()?;
+    unsafe {
+        std::env::set_var("HOME", &cwd);
+    }
+    config::init().await;
+    logger::init().await;
+
+    let backend = TestBackend::new(120, 40);
+    let term = Terminal::new(backend)?;
+    let app = App::new();
+
+    Ok((app, term))
+}
+
+async fn open_instant(app: &mut App, term: &mut Terminal<TestBackend>) -> Result<()> {
+    app.draw_once_on(term)?;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('1'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(term)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn notebook_open_note_with_l_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    open_instant(&mut app, &mut term).await?;
+
+    // select first note and open
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('l'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+
+    // editor shows sample content
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains("Hi :D"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notebook_note_actions_dialog_open_close_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    open_instant(&mut app, &mut term).await?;
+
+    // select note to enable note actions
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+
+    // open note actions dialog
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('m'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains("Note Actions"));
+
+    // close dialog with Esc
+    app.handle_input(Input::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)))
+        .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(!buf.contains("Note Actions"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notebook_directory_actions_dialog_open_close_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    open_instant(&mut app, &mut term).await?;
+
+    // on root directory selection, open directory actions dialog
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('m'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains("Directory Actions"));
+
+    // close dialog with Esc
+    app.handle_input(Input::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)))
+        .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(!buf.contains("Directory Actions"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notebook_keymap_toggle_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    open_instant(&mut app, &mut term).await?;
+
+    // show keymap
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('?'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains(" [?] Hide keymap "));
+
+    // hide keymap
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('?'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(!buf.contains(" [?] Hide keymap "));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notebook_editor_keymap_in_insert_mode_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    open_instant(&mut app, &mut term).await?;
+
+    // open note and enter insert mode
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('l'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('i'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+
+    // show editor keymap with Ctrl+h
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('h'),
+        KeyModifiers::CONTROL,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains("Editor Keymap"));
+
+    // any key closes
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('x'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(!buf.contains("Editor Keymap"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notebook_quit_confirm_then_cancel_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    open_instant(&mut app, &mut term).await?;
+
+    // open note in normal mode (idle)
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('l'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+
+    // Esc opens quit confirmation
+    app.handle_input(Input::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)))
+        .await;
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(buf.contains("Do you want to quit?"));
+
+    // cancel with 'n' (should not quit)
+    let quit = app
+        .handle_input(Input::Key(KeyEvent::new(
+            KeyCode::Char('n'),
+            KeyModifiers::NONE,
+        )))
+        .await;
+    assert!(!quit);
+
+    app.draw_once_on(&mut term)?;
+    let buf = buffer_to_lines(&term).join("\n");
+    assert!(!buf.contains("Do you want to quit?"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notebook_quit_confirm_then_accept_inproc() -> Result<()> {
+    let (mut app, mut term) = setup().await?;
+    open_instant(&mut app, &mut term).await?;
+
+    // open note in normal mode (idle)
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+    app.handle_input(Input::Key(KeyEvent::new(
+        KeyCode::Char('l'),
+        KeyModifiers::NONE,
+    )))
+    .await;
+
+    // Esc then 'y' should quit
+    app.handle_input(Input::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)))
+        .await;
+    let quit = app
+        .handle_input(Input::Key(KeyEvent::new(
+            KeyCode::Char('y'),
+            KeyModifiers::NONE,
+        )))
+        .await;
+    assert!(quit);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds structured, in-process TUI integration tests to the glues (TUI) crate.

Highlights
- Entry tests (4):
  - Enter via selection opens Instant
  - Quit with 'q'
  - Keymap toggle with '?'
  - Help overlay open/close
- Notebook tests (7), using Instant:
  - Open note with 'l' (shows sample content)
  - Note actions dialog open/close ('m', Esc)
  - Directory actions dialog open/close ('m', Esc)
  - Keymap toggle with '?'
  - Editor keymap in insert mode (Ctrl+h)
  - Quit confirmation: cancel with 'n', accept with 'y'

CI considerations
- Tests run under feature flag: glues crate with .
- Ran , 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test entry_quit_with_q_inproc ... ok
test entry_help_overlay_open_close_inproc ... ok
test entry_keymap_toggle_inproc ... ok
test entry_nav_enter_opens_instant_inproc ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 1 test
test home_to_instant_quit_inproc ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s


running 7 tests
test notebook_quit_confirm_then_accept_inproc ... ok
test notebook_open_note_with_l_inproc ... ok
test notebook_quit_confirm_then_cancel_inproc ... ok
test notebook_directory_actions_dialog_open_close_inproc ... ok
test notebook_note_actions_dialog_open_close_inproc ... ok
test notebook_editor_keymap_in_insert_mode_inproc ... ok
test notebook_keymap_toggle_inproc ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s, and  locally.

Files
- tui/tests/entry_inproc.rs
- tui/tests/notebook_inproc.rs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive in‑process UI tests covering navigation and opening entries, quitting via keyboard, toggling the keymap, and opening/closing the help overlay.
  * Added notebook interaction tests: opening notes, showing/hiding Note Actions and Directory Actions dialogs, toggling the keymap, displaying the editor keymap in insert mode, and quit confirmation flows (cancel/accept).
  * Tests simulate realistic key interactions and validate visible UI text to ensure expected on-screen behavior and reliable quit state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->