### PR TITLE
Use text snapshots via insta::assert_snapshot; update snapshots; document snapshot policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - After clippy and tests succeed, run `cargo fmt` on the entire workspace before committing changes.
 - Use file-based module declarations; do **not** create `mod.rs` files.
 - Branch names may contain only lowercase `a`-`z`, dashes (`-`), and slashes (`/`).
+- Insta snapshots: commit only `.snap`; never commit `.snap.new`.

--- a/tui/tests/snapshots/flow_inproc__tester__home_inproc.snap
+++ b/tui/tests/snapshots/flow_inproc__tester__home_inproc.snap
@@ -1,48 +1,36 @@
 ---
 source: tui/tests/tester.rs
-assertion_line: 999
-expression: lines
+expression: text
 snapshot_kind: text
 ---
-[
-    " Glues - TUI note-taking app offering complete data control and flexible storage options              \u{e0be} [?] Show keymap ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                           ████   ███                                                                   ",
-    "                                          ██  ██   ██                                                                   ",
-    "                                         ██        ██    ██  ██   ████    █████                                         ",
-    "                                         ██        ██    ██  ██  ██  ██  ██                                             ",
-    "                                         ██  ███   ██    ██  ██  ██████   ████                                          ",
-    "                                          ██  ██   ██    ██  ██  ██          ██                                         ",
-    "                                           █████  ████    ███ ██  ████   █████                                          ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                         ┌─────────────Open Notes─────────────┐                                         ",
-    "                                         │                                    │                                         ",
-    "                                         │   [1] Instant                      │                                         ",
-    "                                         │   [2] Local                        │                                         ",
-    "                                         │   [3] Git                          │                                         ",
-    "                                         │   [4] MongoDB                      │                                         ",
-    "                                         │   [5] CSV                          │                                         ",
-    "                                         │   [6] JSON                         │                                         ",
-    "                                         │   [h] Help                         │                                         ",
-    "                                         │   [q] Quit                         │                                         ",
-    "                                         │                                    │                                         ",
-    "                                         └────────────────────────────────────┘                                         ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-    "                                                                                                                        ",
-]
+ Glues - TUI note-taking app offering complete data control and flexible storage options               [?] Show keymap 
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                           ████   ███                                                                   
+                                          ██  ██   ██                                                                   
+                                         ██        ██    ██  ██   ████    █████                                         
+                                         ██        ██    ██  ██  ██  ██  ██                                             
+                                         ██  ███   ██    ██  ██  ██████   ████                                          
+                                          ██  ██   ██    ██  ██  ██          ██                                         
+                                           █████  ████    ███ ██  ████   █████                                          
+                                                                                                                        
+                                                                                                                        
+                                         ┌─────────────Open Notes─────────────┐                                         
+                                         │                                    │                                         
+                                         │   [1] Instant                      │                                         
+                                         │   [2] Local                        │                                         
+                                         │   [3] Git                          │                                         
+                                         │   [4] MongoDB                      │                                         
+                                         │   [5] CSV                          │                                         
+                                         │   [6] JSON                         │                                         
+                                         │   [h] Help                         │                                         
+                                         │   [q] Quit                         │                                         
+                                         │                                    │                                         
+                                         └────────────────────────────────────┘

--- a/tui/tests/snapshots/flow_inproc__tester__instant_inproc.snap
+++ b/tui/tests/snapshots/flow_inproc__tester__instant_inproc.snap
@@ -1,48 +1,45 @@
 ---
 source: tui/tests/tester.rs
-assertion_line: 999
-expression: lines
+expression: text
 snapshot_kind: text
 ---
-[
-    " Directory 'Notes' selected                                                                           \u{e0be} [?] Show keymap ",
-    "[Browser]                                   ▐[Editor]                                                                   ",
-    " \u{f0770} Notes                                    ▐ 1 Welcome to Glues :D                                                     ",
-    "   \u{f11d7} Sample Note                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-    "                                            ▐                                                                           ",
-]
+ Directory 'Notes' selected                                                                            [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/tester.rs
+++ b/tui/tests/tester.rs
@@ -79,8 +79,8 @@ impl Tester {
 
     #[allow(dead_code)]
     pub fn assert_snapshot(&self, name: &str) {
-        let lines = buffer_lines(&self.term);
-        insta::assert_debug_snapshot!(name, lines);
+        let text = buffer_lines(&self.term).join("\n");
+        insta::assert_snapshot!(name, text);
     }
 
     async fn handle_input(&mut self, input: Input) -> bool {


### PR DESCRIPTION
Summary

- Switch `Tester::assert_snapshot` to `insta::assert_snapshot!(name, text)` with lines joined for readable text snapshots.
- Regenerate snapshots:
  - `tui/tests/snapshots/flow_inproc__tester__home_inproc.snap`
  - `tui/tests/snapshots/flow_inproc__tester__instant_inproc.snap`
- Add policy to `AGENTS.md`: "Insta snapshots: commit only `.snap`; never commit `.snap.new`."

Validation

- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p glues` (all tests passing)
- `cargo fmt --all`

Notes

- Snapshots now store plain text (no Debug brackets/quotes). Icons render as glyphs instead of `\u{...}`.
- Only tests and docs changed; no production code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified snapshot contribution guidelines: commit only “.snap” files; never commit “.snap.new”.

* **Tests**
  * Updated snapshot assertions to use plain text snapshots instead of debug-formatted lists, improving readability and diff quality.
  * No changes to runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->