### PR TITLE
Replace contains/not_contains tester methods with snapshots

### DIFF
--- a/tui/tests/entry_inproc.rs
+++ b/tui/tests/entry_inproc.rs
@@ -16,9 +16,9 @@ async fn entry_nav_enter_opens_instant_inproc() -> Result<()> {
     t.press('k').await;
     t.key(KeyCode::Enter).await;
 
-    // draw and assert notebook content is visible (e.g., sample note)
+    // draw and snapshot notebook view (e.g., sample note visible)
     t.draw()?;
-    t.assert_contains("Sample Note");
+    t.assert_snapshot("instant_inproc");
 
     Ok(())
 }
@@ -42,12 +42,12 @@ async fn entry_help_overlay_open_close_inproc() -> Result<()> {
     // open help (currently bound to 'a')
     t.press('a').await;
     t.draw()?;
-    t.assert_contains("Press any key to close");
+    t.assert_snapshot("help_open_inproc");
 
     // any key closes help
     t.press('x').await;
     t.draw()?;
-    t.assert_not_contains("Press any key to close");
+    t.assert_snapshot("help_closed_inproc");
 
     Ok(())
 }

--- a/tui/tests/notebook_inproc.rs
+++ b/tui/tests/notebook_inproc.rs
@@ -15,7 +15,7 @@ async fn notebook_open_note_with_l_inproc() -> Result<()> {
     t.draw()?;
 
     // editor shows sample content
-    t.assert_contains("Hi :D");
+    t.assert_snapshot("note_open_inproc");
 
     Ok(())
 }
@@ -31,12 +31,12 @@ async fn notebook_note_actions_dialog_open_close_inproc() -> Result<()> {
     // open note actions dialog
     t.press('m').await;
     t.draw()?;
-    t.assert_contains("Note Actions");
+    t.assert_snapshot("note_actions_open_inproc");
 
     // close dialog with Esc
     t.key(KeyCode::Esc).await;
     t.draw()?;
-    t.assert_not_contains("Note Actions");
+    t.assert_snapshot("note_actions_closed_inproc");
 
     Ok(())
 }
@@ -49,12 +49,12 @@ async fn notebook_directory_actions_dialog_open_close_inproc() -> Result<()> {
     // on root directory selection, open directory actions dialog
     t.press('m').await;
     t.draw()?;
-    t.assert_contains("Directory Actions");
+    t.assert_snapshot("dir_actions_open_inproc");
 
     // close dialog with Esc
     t.key(KeyCode::Esc).await;
     t.draw()?;
-    t.assert_not_contains("Directory Actions");
+    t.assert_snapshot("dir_actions_closed_inproc");
 
     Ok(())
 }
@@ -67,12 +67,12 @@ async fn notebook_keymap_toggle_inproc() -> Result<()> {
     // show keymap
     t.press('?').await;
     t.draw()?;
-    t.assert_contains(" [?] Hide keymap ");
+    t.assert_snapshot("keymap_shown_inproc");
 
     // hide keymap
     t.press('?').await;
     t.draw()?;
-    t.assert_not_contains("Do you want to quit?");
+    t.assert_snapshot("keymap_hidden_inproc");
 
     Ok(())
 }

--- a/tui/tests/snapshots/entry_inproc__tester__help_closed_inproc.snap
+++ b/tui/tests/snapshots/entry_inproc__tester__help_closed_inproc.snap
@@ -1,0 +1,36 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Glues - TUI note-taking app offering complete data control and flexible storage options               [?] Show keymap 
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                           ████   ███                                                                   
+                                          ██  ██   ██                                                                   
+                                         ██        ██    ██  ██   ████    █████                                         
+                                         ██        ██    ██  ██  ██  ██  ██                                             
+                                         ██  ███   ██    ██  ██  ██████   ████                                          
+                                          ██  ██   ██    ██  ██  ██          ██                                         
+                                           █████  ████    ███ ██  ████   █████                                          
+                                                                                                                        
+                                                                                                                        
+                                         ┌─────────────Open Notes─────────────┐                                         
+                                         │                                    │                                         
+                                         │   [1] Instant                      │                                         
+                                         │   [2] Local                        │                                         
+                                         │   [3] Git                          │                                         
+                                         │   [4] MongoDB                      │                                         
+                                         │   [5] CSV                          │                                         
+                                         │   [6] JSON                         │                                         
+                                         │   [h] Help                         │                                         
+                                         │   [q] Quit                         │                                         
+                                         │                                    │                                         
+                                         └────────────────────────────────────┘

--- a/tui/tests/snapshots/entry_inproc__tester__help_open_inproc.snap
+++ b/tui/tests/snapshots/entry_inproc__tester__help_open_inproc.snap
@@ -1,0 +1,42 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Glues - TUI note-taking app offering complete data control and flexible storage options               [?] Show keymap 
+                                                                                                                        
+                                                                                                                        
+┌─────────────────────────────────────────────────────────Help─────────────────────────────────────────────────────────┐
+│                                                                                                                      │
+│  Glues offers various storage options to suit your needs:                                                            │
+│                                                                                                                      │
+│  Instant                                                                                                             │
+│  Data is stored in memory and only persists while the app is running.                                                │
+│  This option is useful for testing or temporary notes as it is entirely volatile.                                    │
+│                                                                                                                      │
+│  Local                                                                                                               │
+│  Notes are stored locally as separate files.                                                                         │
+│  This is the default option for users who prefer a simple, file-based approach without any remote synchronization.   │
+│                                                                                                                      │
+│  Git                                                                                                                 │
+│  Git storage requires three inputs: `path`, `remote`, and `branch`.                                                  │
+│  The `path` should point to an existing local Git repository, similar to the file storage path.                      │
+│  For example, you can clone a GitHub repository and use that path.                                                   │
+│  The `remote` and `branch` specify the target remote repository and branch for synchronization.                      │
+│  When you modify notes or directories, Glues will automatically sync changes with the specified remote repository.   │
+│                                                                                                                      │
+│  MongoDB                                                                                                             │
+│  MongoDB storage allows you to store your notes in a MongoDB database, providing a scalable and centralized          │
+│  solution for managing your notes.                                                                                   │
+│  You need to provide the MongoDB connection string and the database name.                                            │
+│  Glues will handle storing and retrieving notes from the specified database.                                         │
+│  This option is ideal for users who prefer a centralized storage solution or need robust, reliable data storage.     │
+│                                                                                                                      │
+│  CSV or JSON                                                                                                         │
+│  These formats store notes as simple log files, ideal for quick data exports or reading logs.                        │
+│  CSV saves data in comma-separated format, while JSON uses JSONL (JSON Lines) format.                                │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                Press any key to close                                                │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/tui/tests/snapshots/entry_inproc__tester__instant_inproc.snap
+++ b/tui/tests/snapshots/entry_inproc__tester__instant_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Directory 'Notes' selected                                                                            [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__tester__dir_actions_closed_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__tester__dir_actions_closed_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Directory 'Notes' selected                                                                            [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__tester__dir_actions_open_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__tester__dir_actions_open_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Directory actions dialog                                                                              [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ ┌────Directory Actions─────┐                                              
+                                            ▐ │                          │                                              
+                                            ▐ │   Add note               │                                              
+                                            ▐ │   Add directory          │                                              
+                                            ▐ │   Rename directory       │                                              
+                                            ▐ │   Remove directory       │                                              
+                                            ▐ │   Close                  │                                              
+                                            ▐ │                          │                                              
+                                            ▐ └──────────────────────────┘                                              
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__tester__keymap_hidden_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__tester__keymap_hidden_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Directory 'Notes' selected                                                                            [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__tester__keymap_shown_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__tester__keymap_shown_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Directory 'Notes' selected                                                                            [?] Hide keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D         General                                     
+   󱇗 Sample Note                            ▐                               [l]       Toggle directory                  
+                                            ▐                               [h]       Close parent directory            
+                                            ▐                               [j]       Select next                       
+                                            ▐                               [k]       Select previous                   
+                                            ▐                               [J]       Select next directory             
+                                            ▐                               [K]       Select previous directory         
+                                            ▐                               [G]       Select last                       
+                                            ▐                               [1-9]     Add steps                         
+                                            ▐                               [>]       Expand width                      
+                                            ▐                               [<]       Shrink width                      
+                                            ▐                               [Space]   Move directory                    
+                                            ▐                               [m]       Show more actions                 
+                                            ▐                               [Esc]     Quit                              
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__tester__note_actions_closed_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__tester__note_actions_closed_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' selected                                                                           [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__tester__note_actions_open_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__tester__note_actions_open_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Note actions dialog                                                                                   [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ ┌───────Note Actions───────┐                                              
+                                            ▐ │                          │                                              
+                                            ▐ │   Rename note            │                                              
+                                            ▐ │   Remove note            │                                              
+                                            ▐ │   Close                  │                                              
+                                            ▐ │                          │                                              
+                                            ▐ └──────────────────────────┘                                              
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__tester__note_open_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__tester__note_open_inproc.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/tester.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/tester.rs
+++ b/tui/tests/tester.rs
@@ -66,18 +66,6 @@ impl Tester {
     }
 
     #[allow(dead_code)]
-    pub fn assert_contains(&self, needle: &str) {
-        let text = buffer_lines(&self.term).join("\n");
-        assert!(text.contains(needle));
-    }
-
-    #[allow(dead_code)]
-    pub fn assert_not_contains(&self, needle: &str) {
-        let text = buffer_lines(&self.term).join("\n");
-        assert!(!text.contains(needle));
-    }
-
-    #[allow(dead_code)]
     pub fn assert_snapshot(&self, name: &str) {
         let text = buffer_lines(&self.term).join("\n");
         insta::assert_snapshot!(name, text);


### PR DESCRIPTION
Replace tester visibility assertions with Insta text snapshots for full-state diffs.

- Switch all `assert_contains`/`assert_not_contains` calls to snapshots via `insta::assert_snapshot!`.
- Remove `assert_contains` and `assert_not_contains` helper methods.
- Regenerate snapshots; verify tests pass with INSTA_UPDATE=always.
- No .snap.new files included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Migrated multiple interactive UI tests to snapshot-based verification for notebook navigation, dialogs, overlays, and keymap toggling, providing more stable and comprehensive validation of the rendered interface.
  * Removed legacy text-containment test helpers in favor of snapshots.
  * Improves regression detection and cross-environment consistency, enhancing overall release reliability without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->