### PR TITLE
Add snap! macro and remove __tester__ from snapshot names

### DIFF
--- a/tui/tests/entry_inproc.rs
+++ b/tui/tests/entry_inproc.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 mod tester;
 use tester::Tester;
 
@@ -18,7 +19,7 @@ async fn entry_nav_enter_opens_instant_inproc() -> Result<()> {
 
     // draw and snapshot notebook view (e.g., sample note visible)
     t.draw()?;
-    t.assert_snapshot("instant_inproc");
+    snap!(t, "instant_inproc");
 
     Ok(())
 }
@@ -42,12 +43,12 @@ async fn entry_help_overlay_open_close_inproc() -> Result<()> {
     // open help (currently bound to 'a')
     t.press('a').await;
     t.draw()?;
-    t.assert_snapshot("help_open_inproc");
+    snap!(t, "help_open_inproc");
 
     // any key closes help
     t.press('x').await;
     t.draw()?;
-    t.assert_snapshot("help_closed_inproc");
+    snap!(t, "help_closed_inproc");
 
     Ok(())
 }

--- a/tui/tests/flow_inproc.rs
+++ b/tui/tests/flow_inproc.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 mod tester;
 use tester::Tester;
 
@@ -9,11 +10,11 @@ async fn home_to_instant_quit_inproc() -> Result<()> {
 
     // initial home screen
     t.draw()?;
-    t.assert_snapshot("home_inproc");
+    snap!(t, "home_inproc");
 
     // open Instant (in-memory) notebook
     t.open_instant().await?;
-    t.assert_snapshot("instant_inproc");
+    snap!(t, "instant_inproc");
 
     // quit with Ctrl+C
     let quit = t.ctrl('c').await;

--- a/tui/tests/notebook_inproc.rs
+++ b/tui/tests/notebook_inproc.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 mod tester;
 use tester::Tester;
 
@@ -15,7 +16,7 @@ async fn notebook_open_note_with_l_inproc() -> Result<()> {
     t.draw()?;
 
     // editor shows sample content
-    t.assert_snapshot("note_open_inproc");
+    snap!(t, "note_open_inproc");
 
     Ok(())
 }
@@ -31,12 +32,12 @@ async fn notebook_note_actions_dialog_open_close_inproc() -> Result<()> {
     // open note actions dialog
     t.press('m').await;
     t.draw()?;
-    t.assert_snapshot("note_actions_open_inproc");
+    snap!(t, "note_actions_open_inproc");
 
     // close dialog with Esc
     t.key(KeyCode::Esc).await;
     t.draw()?;
-    t.assert_snapshot("note_actions_closed_inproc");
+    snap!(t, "note_actions_closed_inproc");
 
     Ok(())
 }
@@ -49,12 +50,12 @@ async fn notebook_directory_actions_dialog_open_close_inproc() -> Result<()> {
     // on root directory selection, open directory actions dialog
     t.press('m').await;
     t.draw()?;
-    t.assert_snapshot("dir_actions_open_inproc");
+    snap!(t, "dir_actions_open_inproc");
 
     // close dialog with Esc
     t.key(KeyCode::Esc).await;
     t.draw()?;
-    t.assert_snapshot("dir_actions_closed_inproc");
+    snap!(t, "dir_actions_closed_inproc");
 
     Ok(())
 }
@@ -67,12 +68,12 @@ async fn notebook_keymap_toggle_inproc() -> Result<()> {
     // show keymap
     t.press('?').await;
     t.draw()?;
-    t.assert_snapshot("keymap_shown_inproc");
+    snap!(t, "keymap_shown_inproc");
 
     // hide keymap
     t.press('?').await;
     t.draw()?;
-    t.assert_snapshot("keymap_hidden_inproc");
+    snap!(t, "keymap_hidden_inproc");
 
     Ok(())
 }

--- a/tui/tests/snapshots/entry_inproc__help_closed_inproc.snap
+++ b/tui/tests/snapshots/entry_inproc__help_closed_inproc.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/entry_inproc.rs
 expression: text
 snapshot_kind: text
 ---

--- a/tui/tests/snapshots/entry_inproc__help_open_inproc.snap
+++ b/tui/tests/snapshots/entry_inproc__help_open_inproc.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/entry_inproc.rs
 expression: text
 snapshot_kind: text
 ---

--- a/tui/tests/snapshots/entry_inproc__instant_inproc.snap
+++ b/tui/tests/snapshots/entry_inproc__instant_inproc.snap
@@ -1,24 +1,24 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/entry_inproc.rs
 expression: text
 snapshot_kind: text
 ---
- Directory 'Notes' selected                                                                            [?] Hide keymap 
+ Directory 'Notes' selected                                                                            [?] Show keymap 
 [Browser]                                   ▐[Editor]                                                                   
- 󰝰 Notes                                    ▐ 1 Welcome to Glues :D         General                                     
-   󱇗 Sample Note                            ▐                               [l]       Toggle directory                  
-                                            ▐                               [h]       Close parent directory            
-                                            ▐                               [j]       Select next                       
-                                            ▐                               [k]       Select previous                   
-                                            ▐                               [J]       Select next directory             
-                                            ▐                               [K]       Select previous directory         
-                                            ▐                               [G]       Select last                       
-                                            ▐                               [1-9]     Add steps                         
-                                            ▐                               [>]       Expand width                      
-                                            ▐                               [<]       Shrink width                      
-                                            ▐                               [Space]   Move directory                    
-                                            ▐                               [m]       Show more actions                 
-                                            ▐                               [Esc]     Quit                              
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           

--- a/tui/tests/snapshots/flow_inproc__home_inproc.snap
+++ b/tui/tests/snapshots/flow_inproc__home_inproc.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/flow_inproc.rs
 expression: text
 snapshot_kind: text
 ---

--- a/tui/tests/snapshots/flow_inproc__instant_inproc.snap
+++ b/tui/tests/snapshots/flow_inproc__instant_inproc.snap
@@ -1,9 +1,9 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/flow_inproc.rs
 expression: text
 snapshot_kind: text
 ---
- Note actions dialog                                                                                   [?] Show keymap 
+ Directory 'Notes' selected                                                                            [?] Show keymap 
 [Browser]                                   ▐[Editor]                                                                   
  󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
    󱇗 Sample Note                            ▐                                                                           
@@ -20,13 +20,13 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐ ┌───────Note Actions───────┐                                              
-                                            ▐ │                          │                                              
-                                            ▐ │   Rename note            │                                              
-                                            ▐ │   Remove note            │                                              
-                                            ▐ │   Close                  │                                              
-                                            ▐ │                          │                                              
-                                            ▐ └──────────────────────────┘                                              
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           

--- a/tui/tests/snapshots/notebook_inproc__dir_actions_closed_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__dir_actions_closed_inproc.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/notebook_inproc.rs
 expression: text
 snapshot_kind: text
 ---

--- a/tui/tests/snapshots/notebook_inproc__dir_actions_open_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__dir_actions_open_inproc.snap
@@ -1,11 +1,11 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/notebook_inproc.rs
 expression: text
 snapshot_kind: text
 ---
- Note 'Sample Note' normal mode                                                                        [?] Show keymap 
-[Browser]                                   ▐ 󱇗 Sample Note                                                             
- 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+ Directory actions dialog                                                                              [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
    󱇗 Sample Note                            ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
@@ -19,6 +19,15 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
+                                            ▐ ┌────Directory Actions─────┐                                              
+                                            ▐ │                          │                                              
+                                            ▐ │   Add note               │                                              
+                                            ▐ │   Add directory          │                                              
+                                            ▐ │   Rename directory       │                                              
+                                            ▐ │   Remove directory       │                                              
+                                            ▐ │   Close                  │                                              
+                                            ▐ │                          │                                              
+                                            ▐ └──────────────────────────┘                                              
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
@@ -33,13 +42,4 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 
+                                            ▐

--- a/tui/tests/snapshots/notebook_inproc__keymap_hidden_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__keymap_hidden_inproc.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/notebook_inproc.rs
 expression: text
 snapshot_kind: text
 ---

--- a/tui/tests/snapshots/notebook_inproc__keymap_shown_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__keymap_shown_inproc.snap
@@ -1,24 +1,24 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/notebook_inproc.rs
 expression: text
 snapshot_kind: text
 ---
- Note 'Sample Note' selected                                                                           [?] Show keymap 
+ Directory 'Notes' selected                                                                            [?] Hide keymap 
 [Browser]                                   ▐[Editor]                                                                   
- 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
-   󱇗 Sample Note                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D         General                                     
+   󱇗 Sample Note                            ▐                               [l]       Toggle directory                  
+                                            ▐                               [h]       Close parent directory            
+                                            ▐                               [j]       Select next                       
+                                            ▐                               [k]       Select previous                   
+                                            ▐                               [J]       Select next directory             
+                                            ▐                               [K]       Select previous directory         
+                                            ▐                               [G]       Select last                       
+                                            ▐                               [1-9]     Add steps                         
+                                            ▐                               [>]       Expand width                      
+                                            ▐                               [<]       Shrink width                      
+                                            ▐                               [Space]   Move directory                    
+                                            ▐                               [m]       Show more actions                 
+                                            ▐                               [Esc]     Quit                              
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           

--- a/tui/tests/snapshots/notebook_inproc__note_actions_closed_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__note_actions_closed_inproc.snap
@@ -1,9 +1,9 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/notebook_inproc.rs
 expression: text
 snapshot_kind: text
 ---
- Directory 'Notes' selected                                                                            [?] Show keymap 
+ Note 'Sample Note' selected                                                                           [?] Show keymap 
 [Browser]                                   ▐[Editor]                                                                   
  󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
    󱇗 Sample Note                            ▐                                                                           

--- a/tui/tests/snapshots/notebook_inproc__note_actions_open_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__note_actions_open_inproc.snap
@@ -1,9 +1,9 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/notebook_inproc.rs
 expression: text
 snapshot_kind: text
 ---
- Directory 'Notes' selected                                                                            [?] Show keymap 
+ Note actions dialog                                                                                   [?] Show keymap 
 [Browser]                                   ▐[Editor]                                                                   
  󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
    󱇗 Sample Note                            ▐                                                                           
@@ -20,13 +20,13 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
+                                            ▐ ┌───────Note Actions───────┐                                              
+                                            ▐ │                          │                                              
+                                            ▐ │   Rename note            │                                              
+                                            ▐ │   Remove note            │                                              
+                                            ▐ │   Close                  │                                              
+                                            ▐ │                          │                                              
+                                            ▐ └──────────────────────────┘                                              
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           

--- a/tui/tests/snapshots/notebook_inproc__note_open_inproc.snap
+++ b/tui/tests/snapshots/notebook_inproc__note_open_inproc.snap
@@ -1,11 +1,11 @@
 ---
-source: tui/tests/tester.rs
+source: tui/tests/notebook_inproc.rs
 expression: text
 snapshot_kind: text
 ---
- Directory actions dialog                                                                              [?] Show keymap 
-[Browser]                                   ▐[Editor]                                                                   
- 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
    󱇗 Sample Note                            ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
@@ -19,15 +19,6 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐ ┌────Directory Actions─────┐                                              
-                                            ▐ │                          │                                              
-                                            ▐ │   Add note               │                                              
-                                            ▐ │   Add directory          │                                              
-                                            ▐ │   Rename directory       │                                              
-                                            ▐ │   Remove directory       │                                              
-                                            ▐ │   Close                  │                                              
-                                            ▐ │                          │                                              
-                                            ▐ └──────────────────────────┘                                              
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
@@ -42,4 +33,13 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/tester.rs
+++ b/tui/tests/tester.rs
@@ -13,6 +13,16 @@ pub struct Tester {
     pub term: Terminal<TestBackend>,
 }
 
+// Bring a concise snapshot macro into test files.
+// Usage: snap!(t, "name");
+#[allow(unused_macros)]
+macro_rules! snap {
+    ($t:expr, $name:expr) => {{
+        let text = $t.snapshot_text();
+        insta::assert_snapshot!($name, text);
+    }};
+}
+
 impl Tester {
     pub async fn new() -> Result<Self> {
         let cwd = std::env::current_dir()?;
@@ -66,9 +76,8 @@ impl Tester {
     }
 
     #[allow(dead_code)]
-    pub fn assert_snapshot(&self, name: &str) {
-        let text = buffer_lines(&self.term).join("\n");
-        insta::assert_snapshot!(name, text);
+    pub fn snapshot_text(&self) -> String {
+        buffer_lines(&self.term).join("\n")
     }
 
     async fn handle_input(&mut self, input: Input) -> bool {


### PR DESCRIPTION
test(tui): add snap! macro and remove __tester__ from snapshot names

Summary
- Introduce macro `snap!(t, "name")` to snapshot the TUI buffer.
- Call Insta macros from test files so snapshot filenames exclude `__tester__`.
- Replace repeated inline snapshot blocks with the macro for brevity.
- Update snapshots and remove old `__tester__` variants.

Details
- Macro lives in `tui/tests/tester.rs`; tests import it via `#[macro_use] mod tester;` and call `snap!(t, "...")`.
- The macro expands at the call site, so Insta records the test file as the source; filenames remain unchanged except dropping `__tester__`.

Verification
- Ran `INSTA_UPDATE=always cargo test -p glues`; all tests pass.
- Confirmed no `__tester__` snapshots remain in `tui/tests/snapshots`.
