### PR TITLE
Add visual-mode tests and notebook tree mode tests

### DIFF
--- a/tui/tests/editor_visual.rs
+++ b/tui/tests/editor_visual.rs
@@ -1,0 +1,78 @@
+#[macro_use]
+mod tester;
+use tester::Tester;
+
+use color_eyre::Result;
+use ratatui::crossterm::event::KeyCode;
+
+#[tokio::test]
+async fn enter_visual_mode_and_escape() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    t.press('v').await;
+    t.draw()?;
+    snap!(t, "visual_mode");
+
+    t.key(KeyCode::Esc).await;
+    t.draw()?;
+    snap!(t, "visual_back_to_normal");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn visual_numbering_move() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    t.press('v').await;
+    t.press('2').await;
+    t.draw()?;
+    snap!(t, "visual_numbering");
+
+    t.press('j').await;
+    t.draw()?;
+    snap!(t, "visual_move_2_down");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn visual_gateway_mode_top() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    t.press('v').await;
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "visual_gateway");
+
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "visual_move_top");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn editor_keymap_overlay_in_visual_mode() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    t.press('v').await;
+    t.ctrl('h').await;
+    t.draw()?;
+    snap!(t, "visual_keymap_open");
+
+    t.press('x').await;
+    t.draw()?;
+    snap!(t, "visual_keymap_closed");
+
+    Ok(())
+}
+

--- a/tui/tests/editor_visual.rs
+++ b/tui/tests/editor_visual.rs
@@ -75,4 +75,3 @@ async fn editor_keymap_overlay_in_visual_mode() -> Result<()> {
 
     Ok(())
 }
-

--- a/tui/tests/notebook_tree.rs
+++ b/tui/tests/notebook_tree.rs
@@ -22,6 +22,85 @@ async fn opens_note_on_l() -> Result<()> {
 }
 
 #[tokio::test]
+async fn numbering_steps_move_next_prev() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+
+    // enter numbering with '2'
+    t.press('2').await;
+    t.draw()?;
+    snap!(t, "numbering_open");
+
+    // move down by 2
+    t.press('j').await;
+    t.draw()?;
+    snap!(t, "numbering_move_down_2");
+
+    // enter numbering again and move up by 2
+    t.press('2').await;
+    t.press('k').await;
+    t.draw()?;
+    snap!(t, "numbering_move_up_2");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn gateway_mode_enter_and_first_select() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+
+    // enter gateway mode from directory selection
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "gateway_mode");
+
+    // pressing 'g' selects first
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "gateway_mode_select_first");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn move_mode_enter_and_cancel_on_directory() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+
+    // enter move mode on directory (Space)
+    t.key(KeyCode::Char(' ')).await;
+    t.draw()?;
+    snap!(t, "move_mode_directory");
+
+    // cancel with Esc
+    t.key(KeyCode::Esc).await;
+    t.draw()?;
+    snap!(t, "move_mode_cancelled_directory");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn move_mode_enter_and_cancel_on_note() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+
+    // select a note and enter move mode
+    t.press('j').await;
+    t.key(KeyCode::Char(' ')).await;
+    t.draw()?;
+    snap!(t, "move_mode_note");
+
+    // cancel with Esc
+    t.key(KeyCode::Esc).await;
+    t.draw()?;
+    snap!(t, "move_mode_cancelled_note");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn add_note_via_directory_actions() -> Result<()> {
     let mut t = Tester::new().await?;
     t.open_instant().await?;

--- a/tui/tests/snapshots/editor_visual__visual_back_to_normal.snap
+++ b/tui/tests/snapshots/editor_visual__visual_back_to_normal.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_visual__visual_gateway.snap
+++ b/tui/tests/snapshots/editor_visual__visual_gateway.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' visual mode - gateway                                                              [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ VISUAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_visual__visual_keymap_closed.snap
+++ b/tui/tests/snapshots/editor_visual__visual_keymap_closed.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' visual mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ VISUAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_visual__visual_keymap_open.snap
+++ b/tui/tests/snapshots/editor_visual__visual_keymap_open.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' visual mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+               ┌─────────────────────────────────VIM VISUAL MODE KEYMAP─────────────────────────────────┐               
+               │                                                                                        │               
+               │  MOVE CURSOR                                                                           │               
+               │  [h] Move cursor left                                                                  │               
+               │  [j] Move cursor down                                                                  │               
+               │  [k] Move cursor up                                                                    │               
+               │  [l] Move cursor right                                                                 │               
+               │  [w] Move cursor to the start of the next word                                         │               
+               │  [e] Move cursor to the end of the next word                                           │               
+               │  [b] Move cursor to the start of the previous word                                     │               
+               │  [0] Move cursor to the start of the line                                              │               
+               │  [$] Move cursor to the end of the line                                                │               
+               │  [^] Move cursor to the first non-blank character of the line                          │               
+               │  [G] Move cursor to the end of the file                                                │               
+               │                                                                                        │               
+               │  TO INSERT MODE                                                                        │               
+               │  [s] or [S] Substitute selected text and go to insert mode                             │               
+               │                                                                                        │               
+               │  TO EXTENDED MODES                                                                     │               
+               │  [g] Go to gateway mode for additional commands                                        │               
+               │  [1-9] Specify repeat count for subsequent actions                                     │               
+               │                                                                                        │               
+               │  EDIT TEXT AND RETURN TO NORMAL MODE                                                   │               
+               │  [d] or [x] Delete selected text                                                       │               
+               │  [y] Yank (copy) selected text                                                         │               
+               │  [~] Toggle the case of the select text                                                │               
+               │                                                                                        │               
+               │                                                                                        │               
+               │                                 Press any key to close                                 │               
+               │                                                                                        │               
+               └────────────────────────────────────────────────────────────────────────────────────────┘               
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ VISUAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_visual__visual_mode.snap
+++ b/tui/tests/snapshots/editor_visual__visual_mode.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' visual mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ VISUAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_visual__visual_move_2_down.snap
+++ b/tui/tests/snapshots/editor_visual__visual_move_2_down.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' visual mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ VISUAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_visual__visual_move_top.snap
+++ b/tui/tests/snapshots/editor_visual__visual_move_top.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' visual mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ VISUAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_visual__visual_numbering.snap
+++ b/tui/tests/snapshots/editor_visual__visual_numbering.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/editor_visual.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' visual mode, input: '2'                                                            [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ VISUAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/notebook_tree__gateway_mode.snap
+++ b/tui/tests/snapshots/notebook_tree__gateway_mode.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Gateway mode                                                                                          [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__gateway_mode_select_first.snap
+++ b/tui/tests/snapshots/notebook_tree__gateway_mode_select_first.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Directory 'Notes' selected                                                                            [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__move_mode_cancelled_directory.snap
+++ b/tui/tests/snapshots/notebook_tree__move_mode_cancelled_directory.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Directory 'Notes' selected                                                                            [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__move_mode_cancelled_note.snap
+++ b/tui/tests/snapshots/notebook_tree__move_mode_cancelled_note.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' selected                                                                           [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__move_mode_directory.snap
+++ b/tui/tests/snapshots/notebook_tree__move_mode_directory.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Directory move mode: 'Notes'                                                                          [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__move_mode_note.snap
+++ b/tui/tests/snapshots/notebook_tree__move_mode_note.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Note move mode: 'Sample Note'                                                                         [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__numbering_move_down_2.snap
+++ b/tui/tests/snapshots/notebook_tree__numbering_move_down_2.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' selected                                                                           [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__numbering_move_up_2.snap
+++ b/tui/tests/snapshots/notebook_tree__numbering_move_up_2.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Directory 'Notes' selected                                                                            [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐

--- a/tui/tests/snapshots/notebook_tree__numbering_open.snap
+++ b/tui/tests/snapshots/notebook_tree__numbering_open.snap
@@ -1,0 +1,45 @@
+---
+source: tui/tests/notebook_tree.rs
+expression: text
+snapshot_kind: text
+---
+ Steps: '2' selected                                                                                   [?] Show keymap 
+[Browser]                                   ▐[Editor]                                                                   
+ 󰝰 Notes                                    ▐ 1 Welcome to Glues :D                                                     
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐


### PR DESCRIPTION
test(tui): add visual-mode tests and notebook tree mode tests

Summary
- Add editor Visual mode tests: enter/escape, numbering, gateway top, keymap overlay.
- Add Notebook tree mode tests: numbering (steps), gateway mode (select first), move mode (directory/note enter+cancel).
- Remove stray `notebook__*.snap` and the leftover `notebook.rs` source artifacts.

Details
- New files: `tui/tests/editor_visual.rs` and related snapshots.
- Extended `tui/tests/notebook_tree.rs` with mode coverage and snapshots.
- Snapshot prefixes follow file grouping: `editor_visual__*`, `notebook_tree__*`.

Verification
- Regenerated snapshots with `INSTA_UPDATE=always cargo test -p glues`.
- All tests pass locally; snapshot set is clean (no `notebook__*`).
