### PR TITLE
Set up cargo-llvm-cov workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,22 @@
+[alias]
+coverage = [
+    "llvm-cov",
+    "--workspace",
+    "--html"
+]
+coverage-report = [
+    "llvm-cov",
+    "report",
+    "--text"
+]
+coverage-lcov = [
+    "llvm-cov",
+    "--workspace",
+    "--lcov",
+    "--output-path",
+    "target/llvm-cov/lcov.info"
+]
+coverage-clean = [
+    "llvm-cov",
+    "clean"
+]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ Here is our plan for Glues and the features we aim to implement. Below is a list
 * **More Vim Keybindings:** Integrate Vim keybindings for users who prefer Vim-like shortcuts.
 * **Additional Storage Backends:** Support more storage options like Redis and object storage for greater flexibility.
 
+## Development
+
+### Coverage
+
+Install [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) once with:
+
+```bash
+cargo install cargo-llvm-cov
+```
+
+Key commands exposed via project aliases:
+
+- `cargo coverage` - run the workspace under coverage and emit an HTML report at `target/llvm-cov/html/index.html`
+- `cargo coverage-report` - print a text summary (run after `cargo coverage --no-report`; append `--fail-under-lines <N>` to guard CI)
+- `cargo coverage-lcov` - export `target/llvm-cov/lcov.info` for external services
+- `cargo coverage-clean` - remove coverage artifacts
+
 ## License
 
 This project is licensed under the Apache License, Version 2.0 - see the [LICENSE](https://github.com/gluesql/glues/blob/main/LICENSE) file for details.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.89"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools-preview"]


### PR DESCRIPTION
## Summary
- add cargo-llvm-cov cargo aliases for coverage workflows
- document available coverage commands in the README
- add llvm-tools-preview component to the workspace toolchain

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo coverage --no-report
- cargo coverage-report


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Development > Coverage section with instructions for installing coverage tooling and using coverage commands (coverage, coverage-report, coverage-lcov, coverage-clean).

* **Chores**
  * Introduced cargo aliases to simplify running coverage, generating reports (HTML/text/LCOV), and cleaning coverage artifacts.
  * Enabled required LLVM tools in the Rust toolchain to support coverage workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->