### PR TITLE
Automate coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,70 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main, release-*]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure git user
+        run: |
+          git config --global user.email "glues.ci@example.com"
+          git config --global user.name "Glues CI"
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage report
+        run: |
+          mkdir -p coverage
+          cargo llvm-cov --workspace --lcov --output-path coverage/lcov.info
+
+      - name: Compress coverage report
+        run: |
+          xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
+          rm -f coverage/lcov.info
+
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
+
+      - name: Create GitHub App token
+        if: github.repository == 'gluesql/glues' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COVERAGE_APP_ID }}
+          installation-id: ${{ secrets.COVERAGE_APP_INSTALLATION_ID }}
+          private-key: ${{ secrets.COVERAGE_APP_PRIVATE_KEY }}
+          owner: gluesql
+          repositories: glues, gluesql.github.io
+
+      - name: Publish coverage to gluesql.github.io
+        if: github.repository == 'gluesql/glues' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git clone https://github.com/gluesql/gluesql.github.io.git
+          cd gluesql.github.io
+          git checkout gh-pages
+          mkdir -p coverage/glues/main
+          cp ../coverage/lcov.info.xz coverage/glues/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git add coverage/glues/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git commit -m "Coverage: main@${COMMIT_SHA}"
+          git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/gluesql/gluesql.github.io.git
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/lcov.info.xz

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -1,0 +1,133 @@
+name: Publish Coverage
+
+on:
+  workflow_run:
+    workflows: ["Coverage"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID of the triggering Coverage workflow"
+        required: true
+        type: string
+      pr_number:
+        description: "Pull Request number"
+        required: true
+        type: string
+      commit_sha:
+        description: "Head commit SHA for the PR run"
+        required: true
+        type: string
+      artifact_name:
+        description: "Artifact name to download (default: coverage)"
+        required: false
+        default: coverage
+        type: string
+
+jobs:
+  publish:
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.repository == 'gluesql/glues'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Configure git user
+        run: |
+          git config --global user.email "glues.ci@example.com"
+          git config --global user.name "Glues CI"
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COVERAGE_APP_ID }}
+          installation-id: ${{ secrets.COVERAGE_APP_INSTALLATION_ID }}
+          private-key: ${{ secrets.COVERAGE_APP_PRIVATE_KEY }}
+          owner: gluesql
+          repositories: glues, gluesql.github.io
+
+      - name: Set variables for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "RUN_ID=${{ inputs.run_id }}" >> $GITHUB_ENV
+          echo "COMMIT_SHA=${{ inputs.commit_sha }}" >> $GITHUB_ENV
+          echo "PR_NUMBER=${{ inputs.pr_number }}" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${{ inputs.artifact_name }}" >> $GITHUB_ENV
+
+      - name: Set variables for workflow_run
+        if: github.event_name == 'workflow_run'
+        run: |
+          echo "RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
+          echo "COMMIT_SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
+          echo "PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=coverage" >> $GITHUB_ENV
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          run-id: ${{ env.RUN_ID }}
+          path: coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
+
+      - name: Publish coverage to gluesql.github.io
+        run: |
+          git clone https://github.com/gluesql/gluesql.github.io.git
+          cd gluesql.github.io
+          git checkout gh-pages
+          git pull --rebase origin gh-pages
+          mkdir -p coverage/glues/pr/${PR_NUMBER}
+          cp ../coverage/lcov.info.xz coverage/glues/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git add coverage/glues/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git commit -m "Coverage: PR#${PR_NUMBER}@${COMMIT_SHA}"
+          git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/gluesql/gluesql.github.io.git
+
+      - name: Comment coverage link on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const prNumber = process.env.PR_NUMBER;
+            const url = `https://gluesql.org/coverage/?path=glues/pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;
+            const body = [
+              '### Glues Coverage Report',
+              '',
+              `- **Commit:** \`${process.env.COMMIT_SHA}\``,
+              `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
+              `- **Report:** [View report](${url})`
+            ].join('\n');
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            const comment = comments.find(c => c.body.startsWith('### Glues Coverage Report'));
+            if (comment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }


### PR DESCRIPTION
## Summary
- add coverage workflow using cargo-llvm-cov for pushes and pull requests
- publish PR coverage artifacts to gluesql.github.io via GitHub App token

## Testing
- not run (workflow definition only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically generates code coverage on pushes and pull requests.
  - Publishes compressed coverage reports to the project website with timestamped versions.
  - Adds a pull request comment with a direct link to the hosted coverage report.
  - Makes coverage files available as downloadable workflow artifacts.

- Chores
  - Introduces CI workflows to produce, archive, and publish coverage reports.
  - Updates automation to handle tokens, timestamps, and conditional publication across branches and PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->