### PR TITLE
Add snapshot test for local prompt

### DIFF
--- a/tui/tests/entry.rs
+++ b/tui/tests/entry.rs
@@ -52,3 +52,16 @@ async fn help_overlay_toggles() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn open_local_prompt() -> Result<()> {
+    let mut t = Tester::new().await?;
+
+    t.draw()?;
+    // open Local storage prompt via hotkey 2
+    t.press('2').await;
+    t.draw()?;
+    snap!(t, "local_prompt");
+
+    Ok(())
+}

--- a/tui/tests/snapshots/entry__local_prompt.snap
+++ b/tui/tests/snapshots/entry__local_prompt.snap
@@ -1,0 +1,37 @@
+---
+source: tui/tests/entry.rs
+assertion_line: 65
+expression: text
+snapshot_kind: text
+---
+ Glues - TUI note-taking app offering complete data control and flexible storage options               [?] Show keymap 
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                           ████   ███                                                                   
+                                          ██  ██   ██                                                                   
+                                         ██        ██    ██  ██   ████    █████                                         
+                                         ██        ██    ██  ██  ██  ██  ██                                             
+                              ┌──────────────────────────Prompt───────────────────────────┐                             
+                              │                                                           │                             
+                              │  Enter the path:                                          │                             
+                              │  If the path does not exist, it will be created.          │                             
+                              │  ┌─────────────────────────────────────────────────────┐  │                             
+                              │  │                                                     │  │                             
+                              │  └─────────────────────────────────────────────────────┘  │                             
+                              │                                                           │                             
+                              │  [Enter] Submit                                           │                             
+                              │  [Esc] Cancel                                             │                             
+                              │                                                           │                             
+                              └───────────────────────────────────────────────────────────┘                             
+                                         │   [6] JSON                         │                                         
+                                         │   [h] Help                         │                                         
+                                         │   [q] Quit                         │                                         
+                                         │                                    │                                         
+                                         └────────────────────────────────────┘


### PR DESCRIPTION
## Summary
- add TUI snapshot test that opens the Local storage prompt
- capture prompt rendering to guard the entry workflow

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo test --package glues --test entry open_local_prompt -- --nocapture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated test that opens the Local storage prompt via the “2” hotkey and verifies the rendered UI via snapshot.
  * Improves confidence that the Local storage prompt launches and displays correctly after future changes.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->