### PR TITLE
Remap coverage paths

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate coverage report
         run: |
           mkdir -p coverage
-          cargo llvm-cov --workspace --lcov --output-path coverage/lcov.info
+          cargo llvm-cov --workspace --lcov --output-path coverage/lcov.info --remap-path-prefix
 
       - name: Compress coverage report
         run: |


### PR DESCRIPTION
## Summary
- add --remap-path-prefix to cargo llvm-cov invocation
- ensure LCOV files use workspace-relative paths instead of absolute ones

## Testing
- not run (workflow change only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI coverage reporting so generated reports use consistent, simplified file paths across environments.
  * Improves accuracy and portability of coverage metrics in dashboards and PR checks, aiding diagnosis of gaps.
  * No user-facing changes; application behavior and performance remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->