### PR TITLE
Add entry alert snapshot test

### DIFF
--- a/tui/tests/entry.rs
+++ b/tui/tests/entry.rs
@@ -65,3 +65,21 @@ async fn open_local_prompt() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn csv_prompt_empty_shows_alert() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.draw()?;
+
+    // open CSV prompt via hotkey 5
+    t.press('5').await;
+    t.draw()?;
+    snap!(t, "csv_prompt_open");
+
+    // submit empty path to trigger alert
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    snap!(t, "csv_alert");
+
+    Ok(())
+}

--- a/tui/tests/snapshots/entry__csv_alert.snap
+++ b/tui/tests/snapshots/entry__csv_alert.snap
@@ -1,0 +1,37 @@
+---
+source: tui/tests/entry.rs
+assertion_line: 83
+expression: text
+snapshot_kind: text
+---
+ Glues - TUI note-taking app offering complete data control and flexible storage options               [?] Show keymap 
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                           ████   ███                                                                   
+                                          ██  ██   ██                                                                   
+                                         ██        ██    ██  ██   ████    █████                                         
+                                         ██        ██    ██  ██  ██  ██  ██                                             
+                                         ██  ███   ██    ██  ██  ██████   ████                                          
+                                          ██  ██   ██    ██  ██  ██          ██                                         
+                                      ┌───────────────────Alert───────────────────┐                                     
+                                      │                                           │                                     
+                                      │  Path cannot be empty                     │                                     
+                                      │                                           │                                     
+                                      │                                           │                                     
+                                      │          Press any key to close           │                                     
+                                      │                                           │                                     
+                                      └───────────────────────────────────────────┘                                     
+                                         │   [4] MongoDB                      │                                         
+                                         │   [5] CSV                          │                                         
+                                         │   [6] JSON                         │                                         
+                                         │   [h] Help                         │                                         
+                                         │   [q] Quit                         │                                         
+                                         │                                    │                                         
+                                         └────────────────────────────────────┘

--- a/tui/tests/snapshots/entry__csv_prompt_open.snap
+++ b/tui/tests/snapshots/entry__csv_prompt_open.snap
@@ -1,0 +1,37 @@
+---
+source: tui/tests/entry.rs
+assertion_line: 78
+expression: text
+snapshot_kind: text
+---
+ Glues - TUI note-taking app offering complete data control and flexible storage options               [?] Show keymap 
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                           ████   ███                                                                   
+                                          ██  ██   ██                                                                   
+                                         ██        ██    ██  ██   ████    █████                                         
+                                         ██        ██    ██  ██  ██  ██  ██                                             
+                              ┌──────────────────────────Prompt───────────────────────────┐                             
+                              │                                                           │                             
+                              │  Enter the path:                                          │                             
+                              │  If the path does not exist, it will be created.          │                             
+                              │  ┌─────────────────────────────────────────────────────┐  │                             
+                              │  │                                                     │  │                             
+                              │  └─────────────────────────────────────────────────────┘  │                             
+                              │                                                           │                             
+                              │  [Enter] Submit                                           │                             
+                              │  [Esc] Cancel                                             │                             
+                              │                                                           │                             
+                              └───────────────────────────────────────────────────────────┘                             
+                                         │   [6] JSON                         │                                         
+                                         │   [h] Help                         │                                         
+                                         │   [q] Quit                         │                                         
+                                         │                                    │                                         
+                                         └────────────────────────────────────┘


### PR DESCRIPTION
## Summary
- add a TUI snapshot test that opens the CSV prompt and submits empty input
- capture the resulting alert dialog to cover the entry validation path

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo test --package glues --test entry csv_prompt_empty_shows_alert -- --nocapture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added an asynchronous UI test to validate the CSV import prompt behavior when submitting an empty input, ensuring an alert is shown and interactions are correctly rendered between steps.
  - Strengthens coverage for keyboard-driven prompt interactions and alert rendering flows.
  - No changes to user-facing functionality; contributes to improved stability and confidence in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->