### PR TITLE
Add HTTP proxy server and TUI proxy backend option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,8 +1224,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1264,6 +1264,19 @@ dependencies = [
  "tiny_http",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "glues-proxy-server"
+version = "0.7.0"
+dependencies = [
+ "axum",
+ "clap",
+ "color-eyre",
+ "glues-core",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1907,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2056,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -2244,6 +2276,12 @@ dependencies = [
  "rand",
  "serde",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2570,8 +2608,17 @@ checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2582,8 +2629,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3629,7 +3682,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3653,14 +3718,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
-members = ["tui", "core"]
-default-members = ["tui", "core"]
+members = ["tui", "core", "server"]
+default-members = ["tui", "core", "server"]
 
 [workspace.package]
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -31,5 +31,72 @@ pub trait CoreBackend: Send {
     async fn log(&mut self, category: String, message: String) -> Result<()>;
 }
 
+#[async_trait]
+impl CoreBackend for Box<dyn CoreBackend + Send> {
+    fn root_id(&self) -> DirectoryId {
+        (**self).root_id()
+    }
+
+    async fn fetch_directory(&mut self, directory_id: DirectoryId) -> Result<Directory> {
+        (**self).fetch_directory(directory_id).await
+    }
+
+    async fn fetch_directories(&mut self, parent_id: DirectoryId) -> Result<Vec<Directory>> {
+        (**self).fetch_directories(parent_id).await
+    }
+
+    async fn add_directory(&mut self, parent_id: DirectoryId, name: String) -> Result<Directory> {
+        (**self).add_directory(parent_id, name).await
+    }
+
+    async fn remove_directory(&mut self, directory_id: DirectoryId) -> Result<()> {
+        (**self).remove_directory(directory_id).await
+    }
+
+    async fn move_directory(
+        &mut self,
+        directory_id: DirectoryId,
+        parent_id: DirectoryId,
+    ) -> Result<()> {
+        (**self).move_directory(directory_id, parent_id).await
+    }
+
+    async fn rename_directory(&mut self, directory_id: DirectoryId, name: String) -> Result<()> {
+        (**self).rename_directory(directory_id, name).await
+    }
+
+    async fn fetch_notes(&mut self, directory_id: DirectoryId) -> Result<Vec<Note>> {
+        (**self).fetch_notes(directory_id).await
+    }
+
+    async fn fetch_note_content(&mut self, note_id: NoteId) -> Result<String> {
+        (**self).fetch_note_content(note_id).await
+    }
+
+    async fn add_note(&mut self, directory_id: DirectoryId, name: String) -> Result<Note> {
+        (**self).add_note(directory_id, name).await
+    }
+
+    async fn remove_note(&mut self, note_id: NoteId) -> Result<()> {
+        (**self).remove_note(note_id).await
+    }
+
+    async fn rename_note(&mut self, note_id: NoteId, name: String) -> Result<()> {
+        (**self).rename_note(note_id, name).await
+    }
+
+    async fn update_note_content(&mut self, note_id: NoteId, content: String) -> Result<()> {
+        (**self).update_note_content(note_id, content).await
+    }
+
+    async fn move_note(&mut self, note_id: NoteId, directory_id: DirectoryId) -> Result<()> {
+        (**self).move_note(note_id, directory_id).await
+    }
+
+    async fn log(&mut self, category: String, message: String) -> Result<()> {
+        (**self).log(category, message).await
+    }
+}
+
 pub mod local;
 pub mod proxy;

--- a/core/src/backend/proxy/server.rs
+++ b/core/src/backend/proxy/server.rs
@@ -2,15 +2,12 @@ use super::request::ProxyRequest;
 use super::response::{ProxyResponse, ResultPayload};
 use crate::backend::CoreBackend;
 
-pub struct ProxyServer<B> {
-    pub db: B,
+pub struct ProxyServer {
+    pub db: Box<dyn CoreBackend + Send>,
 }
 
-impl<B> ProxyServer<B>
-where
-    B: CoreBackend,
-{
-    pub fn new(db: B) -> Self {
+impl ProxyServer {
+    pub fn new(db: Box<dyn CoreBackend + Send>) -> Self {
         Self { db }
     }
 

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -35,6 +35,9 @@ pub enum EntryEvent {
         conn_str: String,
         db_name: String,
     },
+    OpenProxy {
+        url: String,
+    },
 }
 
 #[derive(Clone, Debug, Display)]

--- a/core/src/glues.rs
+++ b/core/src/glues.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         Event, Result, Transition,
-        backend::local::Db,
+        backend::CoreBackend,
         state::{EntryState, State},
         task::{Task, handle_tasks},
     },
@@ -16,7 +16,7 @@ use {
 };
 
 pub struct Glues {
-    pub db: Option<Db>,
+    pub db: Option<Box<dyn CoreBackend + Send>>,
     pub state: State,
 
     pub task_tx: Sender<Task>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ pub use backend::CoreBackend;
 pub use error::Error;
 pub use event::{EntryEvent, Event, KeyEvent, NotebookEvent, NumKey};
 pub use glues::Glues;
+pub use task::{Task, handle_tasks};
 pub use transition::{EntryTransition, NotebookTransition, Transition};
 
 type Result<T> = std::result::Result<T, Error>;

--- a/core/src/state/entry.rs
+++ b/core/src/state/entry.rs
@@ -1,6 +1,6 @@
 use crate::{
     EntryEvent, EntryTransition, Error, Event, Glues, Result,
-    backend::local::Db,
+    backend::{local::Db, proxy::ProxyClient},
     state::notebook::NotebookState,
     types::{KeymapGroup, KeymapItem},
 };
@@ -19,24 +19,27 @@ impl EntryState {
                 let note_id = db.add_note(root_id, "Sample Note".to_owned()).await?.id;
                 db.update_note_content(note_id, "Hi :D".to_owned()).await?;
 
-                glues.db = Some(db);
+                glues.db = Some(Box::new(db));
                 glues.state = NotebookState::new(glues).await?.into();
                 Ok(EntryTransition::OpenNotebook)
             }
             Entry(OpenCsv(path)) => {
-                glues.db = Db::csv(glues.task_tx.clone(), &path).await.map(Some)?;
+                let db = Db::csv(glues.task_tx.clone(), &path).await?;
+                glues.db = Some(Box::new(db));
                 glues.state = NotebookState::new(glues).await?.into();
 
                 Ok(EntryTransition::OpenNotebook)
             }
             Entry(OpenJson(path)) => {
-                glues.db = Db::json(glues.task_tx.clone(), &path).await.map(Some)?;
+                let db = Db::json(glues.task_tx.clone(), &path).await?;
+                glues.db = Some(Box::new(db));
                 glues.state = NotebookState::new(glues).await?.into();
 
                 Ok(EntryTransition::OpenNotebook)
             }
             Entry(OpenFile(path)) => {
-                glues.db = Db::file(glues.task_tx.clone(), &path).await.map(Some)?;
+                let db = Db::file(glues.task_tx.clone(), &path).await?;
+                glues.db = Some(Box::new(db));
                 glues.state = NotebookState::new(glues).await?.into();
 
                 Ok(EntryTransition::OpenNotebook)
@@ -46,17 +49,22 @@ impl EntryState {
                 remote,
                 branch,
             }) => {
-                glues.db = Db::git(glues.task_tx.clone(), &path, remote, branch)
-                    .await
-                    .map(Some)?;
+                let db = Db::git(glues.task_tx.clone(), &path, remote, branch).await?;
+                glues.db = Some(Box::new(db));
                 glues.state = NotebookState::new(glues).await?.into();
 
                 Ok(EntryTransition::OpenNotebook)
             }
             Entry(OpenMongo { conn_str, db_name }) => {
-                glues.db = Db::mongo(glues.task_tx.clone(), &conn_str, &db_name)
-                    .await
-                    .map(Some)?;
+                let db = Db::mongo(glues.task_tx.clone(), &conn_str, &db_name).await?;
+                glues.db = Some(Box::new(db));
+                glues.state = NotebookState::new(glues).await?.into();
+
+                Ok(EntryTransition::OpenNotebook)
+            }
+            Entry(OpenProxy { url }) => {
+                let client = ProxyClient::connect(url).await?;
+                glues.db = Some(Box::new(client));
                 glues.state = NotebookState::new(glues).await?.into();
 
                 Ok(EntryTransition::OpenNotebook)

--- a/core/src/state/notebook.rs
+++ b/core/src/state/notebook.rs
@@ -45,8 +45,8 @@ impl NotebookState {
         let db = glues.db.as_mut().ok_or(Error::InvalidState(
             "[NotebookState::new] empty db".to_owned(),
         ))?;
-        let root_id = db.root_id.clone();
-        let root_directory = db.fetch_directory(root_id).await?;
+        let root_id = db.root_id();
+        let root_directory = db.fetch_directory(root_id.clone()).await?;
         let notes = db.fetch_notes(root_directory.id.clone()).await?;
         let directories = db
             .fetch_directories(root_directory.id.clone())

--- a/core/tests/proxy.rs
+++ b/core/tests/proxy.rs
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 async fn proxy_backend_operations() {
     let (tx, _rx) = channel();
     let db = Db::memory(tx).await.unwrap();
-    let server = ProxyServer::new(db);
+    let server = ProxyServer::new(Box::new(db));
     let server = Arc::new(Mutex::new(server));
 
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "glues-proxy-server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+glues-core.workspace = true
+tokio = { version = "1.41.0", features = ["macros", "rt-multi-thread", "signal"] }
+axum = "0.7"
+clap = { version = "4.5.4", features = ["derive"] }
+color-eyre = "0.6.3"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,0 +1,150 @@
+use {
+    axum::{
+        Json, Router,
+        extract::State,
+        http::StatusCode,
+        routing::{get, post},
+    },
+    clap::{Parser, Subcommand},
+    color_eyre::Result,
+    glues_core::{
+        Task, Transition,
+        backend::{
+            CoreBackend,
+            local::Db,
+            proxy::{ProxyServer, request::ProxyRequest, response::ProxyResponse},
+        },
+        handle_tasks,
+    },
+    std::{
+        collections::VecDeque,
+        net::SocketAddr,
+        sync::{
+            Arc, Mutex,
+            mpsc::{Sender, channel},
+        },
+        time::Duration,
+    },
+    tokio::{net::TcpListener, signal, sync::Mutex as AsyncMutex, time::sleep},
+    tracing::{error, info},
+    tracing_subscriber::EnvFilter,
+};
+
+#[derive(Parser)]
+#[command(author, version, about = "Glues proxy server")]
+struct Cli {
+    #[arg(long, default_value = "127.0.0.1:4000")]
+    listen: SocketAddr,
+
+    #[command(subcommand)]
+    storage: StorageCommand,
+}
+
+#[derive(Subcommand, Clone)]
+enum StorageCommand {
+    /// In-memory storage (data resets on restart)
+    Memory,
+    /// File storage backend rooted at the given path
+    File { path: String },
+    /// CSV storage backend rooted at the given path
+    Csv { path: String },
+    /// JSON storage backend rooted at the given path
+    Json { path: String },
+    /// Git storage backend
+    Git {
+        path: String,
+        remote: String,
+        branch: String,
+    },
+    /// MongoDB storage backend
+    Mongo { conn_str: String, db_name: String },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse()?))
+        .with_target(false)
+        .init();
+
+    let cli = Cli::parse();
+
+    let (task_tx, task_rx) = channel();
+    let transition_queue = Arc::new(Mutex::new(VecDeque::<Transition>::new()));
+    let _task_handle = handle_tasks(task_rx, &transition_queue);
+    spawn_transition_drain(Arc::clone(&transition_queue));
+
+    let backend = build_backend(cli.storage, task_tx).await?;
+    let server = Arc::new(AsyncMutex::new(ProxyServer::new(backend)));
+
+    let app = Router::new()
+        .route("/", post(handle_proxy))
+        .route("/health", get(health))
+        .with_state(server.clone());
+
+    let listener = TcpListener::bind(cli.listen).await?;
+    info!("listening on {}", cli.listen);
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    Ok(())
+}
+
+async fn build_backend(
+    storage: StorageCommand,
+    task_tx: Sender<Task>,
+) -> Result<Box<dyn CoreBackend + Send>> {
+    let backend: Box<dyn CoreBackend + Send> = match storage {
+        StorageCommand::Memory => Box::new(Db::memory(task_tx.clone()).await?),
+        StorageCommand::File { path } => Box::new(Db::file(task_tx.clone(), &path).await?),
+        StorageCommand::Csv { path } => Box::new(Db::csv(task_tx.clone(), &path).await?),
+        StorageCommand::Json { path } => Box::new(Db::json(task_tx.clone(), &path).await?),
+        StorageCommand::Git {
+            path,
+            remote,
+            branch,
+        } => Box::new(Db::git(task_tx.clone(), &path, remote, branch).await?),
+        StorageCommand::Mongo { conn_str, db_name } => {
+            Box::new(Db::mongo(task_tx, &conn_str, &db_name).await?)
+        }
+    };
+
+    Ok(backend)
+}
+
+async fn handle_proxy(
+    State(server): State<Arc<AsyncMutex<ProxyServer>>>,
+    Json(request): Json<ProxyRequest>,
+) -> (StatusCode, Json<ProxyResponse>) {
+    let mut server = server.lock_owned().await;
+    let response = server.handle(request).await;
+    (StatusCode::OK, Json(response))
+}
+
+async fn health() -> StatusCode {
+    StatusCode::OK
+}
+
+fn spawn_transition_drain(queue: Arc<Mutex<VecDeque<Transition>>>) {
+    tokio::spawn(async move {
+        loop {
+            {
+                let mut guard = queue.lock().expect("transition queue poisoned");
+                guard.clear();
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    });
+}
+
+async fn shutdown_signal() {
+    if let Err(err) = signal::ctrl_c().await {
+        error!("failed to install Ctrl+C handler: {err}");
+        return;
+    }
+
+    info!("shutting down");
+}

--- a/tui/src/config.rs
+++ b/tui/src/config.rs
@@ -16,6 +16,7 @@ pub const LAST_GIT_REMOTE: &str = "last_git_remote";
 pub const LAST_GIT_BRANCH: &str = "last_git_branch";
 pub const LAST_MONGO_CONN_STR: &str = "last_mongo_conn_str";
 pub const LAST_MONGO_DB_NAME: &str = "last_mongo_db_name";
+pub const LAST_PROXY_URL: &str = "last_proxy_url";
 
 const PATH: &str = ".glues/";
 
@@ -48,6 +49,7 @@ pub async fn init() {
         (LAST_GIT_BRANCH, "main"),
         (LAST_MONGO_CONN_STR, ""),
         (LAST_MONGO_DB_NAME, ""),
+        (LAST_PROXY_URL, ""),
     ] {
         let _ = table("config")
             .insert()

--- a/tui/src/context/entry.rs
+++ b/tui/src/context/entry.rs
@@ -2,7 +2,8 @@ use {
     crate::{
         action::{Action, OpenGitStep, OpenMongoStep, TuiAction},
         config::{
-            self, LAST_CSV_PATH, LAST_FILE_PATH, LAST_GIT_PATH, LAST_JSON_PATH, LAST_MONGO_CONN_STR,
+            self, LAST_CSV_PATH, LAST_FILE_PATH, LAST_GIT_PATH, LAST_JSON_PATH,
+            LAST_MONGO_CONN_STR, LAST_PROXY_URL,
         },
         logger::*,
         theme::THEME,
@@ -17,10 +18,11 @@ pub const GIT: &str = "[3] Git";
 pub const MONGO: &str = "[4] MongoDB";
 pub const CSV: &str = "[5] CSV";
 pub const JSON: &str = "[6] JSON";
+pub const PROXY: &str = "[7] Proxy";
 pub const HELP: &str = "[h] Help";
 pub const QUIT: &str = "[q] Quit";
 
-pub const MENU_ITEMS: [&str; 8] = [INSTANT, FILE, GIT, MONGO, CSV, JSON, HELP, QUIT];
+pub const MENU_ITEMS: [&str; 9] = [INSTANT, FILE, GIT, MONGO, CSV, JSON, PROXY, HELP, QUIT];
 
 pub struct EntryContext {
     pub list_state: ListState,
@@ -73,6 +75,18 @@ impl EntryContext {
             .into()
         };
 
+        let open_proxy = || async move {
+            TuiAction::Prompt {
+                message: vec![
+                    Line::raw("Enter the proxy server URL:"),
+                    Line::from("e.g. http://127.0.0.1:4000".fg(THEME.hint)),
+                ],
+                action: Box::new(TuiAction::OpenProxy.into()),
+                default: config::get(LAST_PROXY_URL).await,
+            }
+            .into()
+        };
+
         match code {
             KeyCode::Char('q') => TuiAction::Quit.into(),
             KeyCode::Char('j') | KeyCode::Down => {
@@ -89,6 +103,7 @@ impl EntryContext {
             KeyCode::Char('4') => open_mongo().await,
             KeyCode::Char('5') => open(LAST_CSV_PATH, TuiAction::OpenCsv).await,
             KeyCode::Char('6') => open(LAST_JSON_PATH, TuiAction::OpenJson).await,
+            KeyCode::Char('7') => open_proxy().await,
             KeyCode::Char('a') => TuiAction::Help.into(),
 
             KeyCode::Enter => {
@@ -103,6 +118,7 @@ impl EntryContext {
                     MONGO => open_mongo().await,
                     CSV => open(LAST_CSV_PATH, TuiAction::OpenCsv).await,
                     JSON => open(LAST_JSON_PATH, TuiAction::OpenJson).await,
+                    PROXY => open_proxy().await,
                     HELP => TuiAction::Help.into(),
                     QUIT => TuiAction::Quit.into(),
                     _ => Action::None,

--- a/tui/tests/snapshots/entry__csv_alert.snap
+++ b/tui/tests/snapshots/entry__csv_alert.snap
@@ -1,6 +1,6 @@
 ---
 source: tui/tests/entry.rs
-assertion_line: 83
+assertion_line: 82
 expression: text
 snapshot_kind: text
 ---
@@ -31,7 +31,7 @@ snapshot_kind: text
                                          │   [4] MongoDB                      │                                         
                                          │   [5] CSV                          │                                         
                                          │   [6] JSON                         │                                         
+                                         │   [7] Proxy                        │                                         
                                          │   [h] Help                         │                                         
-                                         │   [q] Quit                         │                                         
                                          │                                    │                                         
                                          └────────────────────────────────────┘

--- a/tui/tests/snapshots/entry__csv_prompt_open.snap
+++ b/tui/tests/snapshots/entry__csv_prompt_open.snap
@@ -1,6 +1,6 @@
 ---
 source: tui/tests/entry.rs
-assertion_line: 78
+assertion_line: 77
 expression: text
 snapshot_kind: text
 ---
@@ -31,7 +31,7 @@ snapshot_kind: text
                               │                                                           │                             
                               └───────────────────────────────────────────────────────────┘                             
                                          │   [6] JSON                         │                                         
+                                         │   [7] Proxy                        │                                         
                                          │   [h] Help                         │                                         
-                                         │   [q] Quit                         │                                         
                                          │                                    │                                         
                                          └────────────────────────────────────┘

--- a/tui/tests/snapshots/entry__help_closed.snap
+++ b/tui/tests/snapshots/entry__help_closed.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/tests/entry.rs
+assertion_line: 51
 expression: text
 snapshot_kind: text
 ---
@@ -30,7 +31,7 @@ snapshot_kind: text
                                          │   [4] MongoDB                      │                                         
                                          │   [5] CSV                          │                                         
                                          │   [6] JSON                         │                                         
+                                         │   [7] Proxy                        │                                         
                                          │   [h] Help                         │                                         
-                                         │   [q] Quit                         │                                         
                                          │                                    │                                         
                                          └────────────────────────────────────┘

--- a/tui/tests/snapshots/entry__local_prompt.snap
+++ b/tui/tests/snapshots/entry__local_prompt.snap
@@ -1,6 +1,6 @@
 ---
 source: tui/tests/entry.rs
-assertion_line: 65
+assertion_line: 64
 expression: text
 snapshot_kind: text
 ---
@@ -31,7 +31,7 @@ snapshot_kind: text
                               │                                                           │                             
                               └───────────────────────────────────────────────────────────┘                             
                                          │   [6] JSON                         │                                         
+                                         │   [7] Proxy                        │                                         
                                          │   [h] Help                         │                                         
-                                         │   [q] Quit                         │                                         
                                          │                                    │                                         
                                          └────────────────────────────────────┘


### PR DESCRIPTION
## Summary
- add  crate that hosts the existing core ProxyServer over HTTP using axum
- switch the app runtime to store  so proxy client and local backends share one path
- extend the TUI entry menu with a proxy option, persist last proxy URL, and update snapshots

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo coverage --no-report