### PR TITLE
Use alpha shortcuts for entry storage menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Glues offers various storage options to suit your needs:
 * **Proxy**:
   - Point Glues at an HTTP proxy that exposes the same set of operations as the local backend.
   - Run the bundled proxy server with `cargo run -p glues-server -- memory` (replace `memory` with `file`, `git`, or `mongo` as needed). The server listens on `127.0.0.1:4000` by default; use `--listen` to change the address.
-  - In the TUI entry menu choose `Proxy` (option `[5]` on the native build), enter the proxy URL (e.g. `http://127.0.0.1:4000`), and Glues will talk to the remote backend just like it does locally.
+  - In the TUI entry menu choose `Proxy` (shortcut `[p]`), enter the proxy URL (e.g. `http://127.0.0.1:4000`), and Glues will talk to the remote backend just like it does locally.
   - After installing via `cargo install glues`, start the proxy with `glues server memory` (or `file`, `git`, `mongo`) to use the same executable for both client and server flows.
 
 > **Web build:** The browser version of Glues persists configuration through GlueSQL WebStorage (LocalStorage) and currently exposes the **Instant** and **Proxy** backends. Point the Proxy option at a running Glues proxy server to keep data outside the browser sandbox.

--- a/tui/src/context/entry.rs
+++ b/tui/src/context/entry.rs
@@ -16,17 +16,17 @@ use crate::{
     config::{LAST_FILE_PATH, LAST_GIT_PATH, LAST_MONGO_CONN_STR},
 };
 
-pub const INSTANT: &str = "[1] Instant";
+pub const INSTANT: &str = "[i] Instant";
 #[cfg(not(target_arch = "wasm32"))]
-pub const FILE: &str = "[2] Local";
+pub const FILE: &str = "[l] Local";
 #[cfg(not(target_arch = "wasm32"))]
-pub const GIT: &str = "[3] Git";
+pub const GIT: &str = "[g] Git";
 #[cfg(not(target_arch = "wasm32"))]
-pub const MONGO: &str = "[4] MongoDB";
+pub const MONGO: &str = "[m] MongoDB";
 #[cfg(target_arch = "wasm32")]
-pub const PROXY: &str = "[2] Proxy";
+pub const PROXY: &str = "[p] Proxy";
 #[cfg(not(target_arch = "wasm32"))]
-pub const PROXY: &str = "[5] Proxy";
+pub const PROXY: &str = "[p] Proxy";
 pub const HELP: &str = "[h] Help";
 pub const QUIT: &str = "[q] Quit";
 
@@ -111,18 +111,15 @@ impl EntryContext {
                 self.list_state.select_previous();
                 Action::None
             }
-            KeyCode::Char('1') => EntryEvent::OpenMemory.into(),
+            KeyCode::Char('i') => EntryEvent::OpenMemory.into(),
             #[cfg(not(target_arch = "wasm32"))]
-            KeyCode::Char('2') => open(LAST_FILE_PATH, TuiAction::OpenFile).await,
+            KeyCode::Char('l') => open(LAST_FILE_PATH, TuiAction::OpenFile).await,
             #[cfg(not(target_arch = "wasm32"))]
-            KeyCode::Char('3') => open_git().await,
+            KeyCode::Char('g') => open_git().await,
             #[cfg(not(target_arch = "wasm32"))]
-            KeyCode::Char('4') => open_mongo().await,
-            #[cfg(not(target_arch = "wasm32"))]
-            KeyCode::Char('5') => open_proxy().await,
-            #[cfg(target_arch = "wasm32")]
-            KeyCode::Char('2') => open_proxy().await,
-            KeyCode::Char('a') => TuiAction::Help.into(),
+            KeyCode::Char('m') => open_mongo().await,
+            KeyCode::Char('p') => open_proxy().await,
+            KeyCode::Char('h') => TuiAction::Help.into(),
 
             KeyCode::Enter => {
                 let i = self

--- a/tui/tests/entry.rs
+++ b/tui/tests/entry.rs
@@ -39,8 +39,8 @@ async fn help_overlay_toggles() -> Result<()> {
     let mut t = Tester::new().await?;
     t.draw()?;
 
-    // open help (currently bound to 'a')
-    t.press('a').await;
+    // open help via shortcut
+    t.press('h').await;
     t.draw()?;
     snap!(t, "help_open");
 
@@ -58,8 +58,8 @@ async fn open_local_prompt() -> Result<()> {
     let mut t = Tester::new().await?;
 
     t.draw()?;
-    // open Local storage prompt via hotkey 2
-    t.press('2').await;
+    // open Local storage prompt via hotkey 'l'
+    t.press('l').await;
     t.draw()?;
     snap!(t, "local_prompt");
 
@@ -71,13 +71,8 @@ async fn proxy_prompt_open() -> Result<()> {
     let mut t = Tester::new().await?;
     t.draw()?;
 
-    // open Proxy prompt via hotkey (5 on native, 2 on wasm)
-    let key = if cfg!(target_arch = "wasm32") {
-        '2'
-    } else {
-        '5'
-    };
-    t.press(key).await;
+    // open Proxy prompt via hotkey 'p'
+    t.press('p').await;
     t.draw()?;
     snap!(t, "proxy_prompt_open");
 

--- a/tui/tests/snapshots/entry__help_closed.snap
+++ b/tui/tests/snapshots/entry__help_closed.snap
@@ -25,11 +25,11 @@ snapshot_kind: text
                                                                                                                         
                                          ┌─────────────Open Notes─────────────┐                                         
                                          │                                    │                                         
-                                         │   [1] Instant                      │                                         
-                                         │   [2] Local                        │                                         
-                                         │   [3] Git                          │                                         
-                                         │   [4] MongoDB                      │                                         
-                                         │   [5] Proxy                        │                                         
+                                         │   [i] Instant                      │                                         
+                                         │   [l] Local                        │                                         
+                                         │   [g] Git                          │                                         
+                                         │   [m] MongoDB                      │                                         
+                                         │   [p] Proxy                        │                                         
                                          │   [h] Help                         │                                         
                                          │   [q] Quit                         │                                         
                                          │                                    │                                         

--- a/tui/tests/tester.rs
+++ b/tui/tests/tester.rs
@@ -71,7 +71,7 @@ impl Tester {
     #[allow(dead_code)]
     pub async fn open_instant(&mut self) -> Result<()> {
         self.draw()?;
-        let _ = self.press('1').await;
+        let _ = self.press('i').await;
         self.draw()?;
         Ok(())
     }


### PR DESCRIPTION
## Summary
- label entry menu items with `[i/l/g/m/p]` instead of `[1-5]`
- update shortcut handling so both native and web builds share the same keys
- refresh entry tests, snapshots, and README docs to match the new bindings

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo fmt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streamlined TUI navigation: numeric menu keys replaced with letter shortcuts — i (Instant), l (Local), g (Git), m (MongoDB), p (Proxy), h (Help). Proxy now consistently uses p across all environments.
- Documentation
  - Updated README to reflect the new Proxy shortcut [p].
- Tests
  - Adjusted test flows to use the new keyboard shortcuts, removing environment-specific conditions for Proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->