### PR TITLE
Add notebook quit menu dialog

### DIFF
--- a/tui/src/context.rs
+++ b/tui/src/context.rs
@@ -141,6 +141,7 @@ impl Context {
             };
 
             match code {
+                #[cfg(not(target_arch = "wasm32"))]
                 KeyCode::Char('q') => {
                     let menu = self.quit_menu.take().log_expect("quit menu must be some");
                     return menu.quit_action;

--- a/tui/src/context/entry.rs
+++ b/tui/src/context/entry.rs
@@ -34,7 +34,7 @@ pub const QUIT: &str = "[q] Quit";
 #[cfg(not(target_arch = "wasm32"))]
 pub const MENU_ITEMS: [&str; 8] = [INSTANT, FILE, GIT, MONGO, PROXY, HELP, THEME_MENU, QUIT];
 #[cfg(target_arch = "wasm32")]
-pub const MENU_ITEMS: [&str; 5] = [INSTANT, PROXY, HELP, THEME_MENU, QUIT];
+pub const MENU_ITEMS: [&str; 4] = [INSTANT, PROXY, HELP, THEME_MENU];
 
 pub struct EntryContext {
     pub list_state: ListState,
@@ -103,6 +103,7 @@ impl EntryContext {
         };
 
         match code {
+            #[cfg(not(target_arch = "wasm32"))]
             KeyCode::Char('q') => TuiAction::Quit.into(),
             KeyCode::Char('j') | KeyCode::Down => {
                 self.list_state.select_next();
@@ -139,6 +140,7 @@ impl EntryContext {
                     PROXY => open_proxy().await,
                     HELP => TuiAction::Help.into(),
                     THEME_MENU => TuiAction::OpenThemeMenu.into(),
+                    #[cfg(not(target_arch = "wasm32"))]
                     QUIT => TuiAction::Quit.into(),
                     _ => Action::None,
                 }

--- a/tui/src/context/notebook.rs
+++ b/tui/src/context/notebook.rs
@@ -411,9 +411,8 @@ impl NotebookContext {
 
                 Action::PassThrough
             }
-            KeyCode::Esc => TuiAction::Confirm {
-                message: "Do you want to quit?".to_owned(),
-                action: Box::new(TuiAction::Quit.into()),
+            KeyCode::Esc => TuiAction::OpenNotebookQuitMenu {
+                save_before_open: false,
             }
             .into(),
             _ => Action::PassThrough,
@@ -427,9 +426,8 @@ impl NotebookContext {
         };
 
         match code {
-            KeyCode::Esc if idle => TuiAction::SaveAndConfirm {
-                message: "Do you want to quit?".to_owned(),
-                action: Box::new(TuiAction::Quit.into()),
+            KeyCode::Esc if idle => TuiAction::OpenNotebookQuitMenu {
+                save_before_open: true,
             }
             .into(),
             KeyCode::Tab if idle => {

--- a/tui/src/views/dialog.rs
+++ b/tui/src/views/dialog.rs
@@ -6,6 +6,7 @@ mod help;
 mod keymap;
 mod note_actions;
 mod prompt;
+mod quit_menu;
 mod theme;
 mod vim_keymap;
 
@@ -34,6 +35,9 @@ pub fn draw(frame: &mut Frame, state: &State, context: &mut Context) {
         return;
     } else if context.alert.is_some() {
         alert::draw(frame, context);
+        return;
+    } else if context.quit_menu.is_some() {
+        quit_menu::draw(frame, context);
         return;
     } else if context.confirm.is_some() {
         confirm::draw(frame, context);

--- a/tui/src/views/dialog/quit_menu.rs
+++ b/tui/src/views/dialog/quit_menu.rs
@@ -41,26 +41,31 @@ pub fn draw(frame: &mut Frame, context: &mut Context) {
     let key_style = Style::default().fg(THEME.text);
     let hint_style = Style::default().fg(THEME.text_secondary);
 
-    let options = Paragraph::new(vec![
-        Line::from(vec![
-            Span::styled("[m]", key_style),
-            Span::raw(" "),
-            Span::styled("Back to menu", hint_style),
-        ]),
-        Line::from(vec![
+    let mut lines = vec![Line::from(vec![
+        Span::styled("[m]", key_style),
+        Span::raw(" "),
+        Span::styled("Back to menu", hint_style),
+    ])];
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        lines.push(Line::from(vec![
             Span::styled("[q]", key_style),
             Span::raw(" "),
             Span::styled("Quit", hint_style),
-        ]),
-        Line::from(vec![
-            Span::styled("[Esc]", key_style),
-            Span::raw(" "),
-            Span::styled("Cancel", hint_style),
-        ]),
-    ])
-    .wrap(Wrap { trim: true })
-    .style(Style::default())
-    .alignment(Alignment::Left);
+        ]));
+    }
+
+    lines.push(Line::from(vec![
+        Span::styled("[Esc]", key_style),
+        Span::raw(" "),
+        Span::styled("Cancel", hint_style),
+    ]));
+
+    let options = Paragraph::new(lines)
+        .wrap(Wrap { trim: true })
+        .style(Style::default())
+        .alignment(Alignment::Left);
 
     frame.render_widget(Clear, area);
     frame.render_widget(block, area);

--- a/tui/src/views/dialog/quit_menu.rs
+++ b/tui/src/views/dialog/quit_menu.rs
@@ -1,0 +1,69 @@
+use {
+    crate::{context::Context, logger::*, theme::THEME},
+    ratatui::{
+        Frame,
+        layout::{Alignment, Constraint::Length, Flex, Layout},
+        style::{Style, Stylize},
+        text::{Line, Span},
+        widgets::{Block, Clear, Padding, Paragraph, Wrap},
+    },
+};
+
+pub fn draw(frame: &mut Frame, context: &mut Context) {
+    let [area] = Layout::horizontal([Length(44)])
+        .flex(Flex::Center)
+        .areas(frame.area());
+    let [area] = Layout::vertical([Length(11)])
+        .flex(Flex::Center)
+        .areas(area);
+
+    let block = Block::bordered()
+        .bg(THEME.surface)
+        .fg(THEME.text)
+        .padding(Padding::new(2, 2, 1, 1))
+        .title("Notebook")
+        .title_alignment(Alignment::Center);
+    let inner_area = block.inner(area);
+    let [message_area, options_area] = Layout::vertical([Length(4), Length(4)])
+        .flex(Flex::SpaceBetween)
+        .areas(inner_area);
+
+    let menu = context
+        .quit_menu
+        .as_ref()
+        .log_expect("quit menu must be some");
+
+    let message = Paragraph::new(menu.message.as_str())
+        .wrap(Wrap { trim: true })
+        .style(Style::default())
+        .alignment(Alignment::Left);
+
+    let key_style = Style::default().fg(THEME.text);
+    let hint_style = Style::default().fg(THEME.text_secondary);
+
+    let options = Paragraph::new(vec![
+        Line::from(vec![
+            Span::styled("[m]", key_style),
+            Span::raw(" "),
+            Span::styled("Back to menu", hint_style),
+        ]),
+        Line::from(vec![
+            Span::styled("[q]", key_style),
+            Span::raw(" "),
+            Span::styled("Quit", hint_style),
+        ]),
+        Line::from(vec![
+            Span::styled("[Esc]", key_style),
+            Span::raw(" "),
+            Span::styled("Cancel", hint_style),
+        ]),
+    ])
+    .wrap(Wrap { trim: true })
+    .style(Style::default())
+    .alignment(Alignment::Left);
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    frame.render_widget(message, message_area);
+    frame.render_widget(options, options_area);
+}

--- a/tui/tests/editor_normal.rs
+++ b/tui/tests/editor_normal.rs
@@ -6,33 +6,47 @@ use color_eyre::Result;
 use glues_tui::input::KeyCode;
 
 #[tokio::test]
-async fn quits_on_esc_then_y() -> Result<()> {
+async fn quits_on_esc_then_q() -> Result<()> {
     let mut t = Tester::new().await?;
     t.open_instant().await?;
 
     t.open_first_note().await?;
 
-    // Esc then 'y' should quit
+    // Esc then 'q' should quit
     t.key(KeyCode::Esc).await;
-    let quit = t.press('y').await;
+    let quit = t.press('q').await;
     assert!(quit);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn quit_confirm_cancel_from_normal() -> Result<()> {
+async fn quit_menu_cancel_from_normal() -> Result<()> {
     let mut t = Tester::new().await?;
     t.open_instant().await?;
     t.open_first_note().await?;
 
     t.key(KeyCode::Esc).await;
     t.draw()?;
-    snap!(t, "quit_confirm_open");
+    snap!(t, "quit_menu_open");
 
-    t.press('n').await;
+    t.key(KeyCode::Esc).await;
     t.draw()?;
-    snap!(t, "quit_confirm_closed");
+    snap!(t, "quit_menu_closed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn quit_menu_returns_to_entry() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+
+    t.key(KeyCode::Esc).await;
+    let quit = t.press('m').await;
+    assert!(!quit);
+
+    t.draw()?;
+    snap!(t, "entry_after_quit_menu");
     Ok(())
 }
 

--- a/tui/tests/snapshots/editor_normal__entry_after_quit_menu.snap
+++ b/tui/tests/snapshots/editor_normal__entry_after_quit_menu.snap
@@ -1,0 +1,37 @@
+---
+source: tui/tests/editor_normal.rs
+assertion_line: 49
+expression: text
+snapshot_kind: text
+---
+ Glues - TUI note-taking app offering complete data control and flexible storage options               [?] Show keymap 
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                           ████   ███                                                                   
+                                          ██  ██   ██                                                                   
+                                         ██        ██    ██  ██   ████    █████                                         
+                                         ██        ██    ██  ██  ██  ██  ██                                             
+                                         ██  ███   ██    ██  ██  ██████   ████                                          
+                                          ██  ██   ██    ██  ██  ██          ██                                         
+                                           █████  ████    ███ ██  ████   █████                                          
+                                                                                                                        
+                                                                                                                        
+                                         ┌─────────────Open Notes─────────────┐                                         
+                                         │                                    │                                         
+                                         │   [i] Instant                      │                                         
+                                         │   [l] Local                        │                                         
+                                         │   [g] Git                          │                                         
+                                         │   [m] MongoDB                      │                                         
+                                         │   [p] Proxy                        │                                         
+                                         │   [h] Help                         │                                         
+                                         │   [t] Theme                        │                                         
+                                         │   [q] Quit                         │                                         
+                                         │                                    │                                         
+                                         └────────────────────────────────────┘

--- a/tui/tests/snapshots/editor_normal__quit_menu_closed.snap
+++ b/tui/tests/snapshots/editor_normal__quit_menu_closed.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/tests/editor_normal.rs
+assertion_line: 35
 expression: text
 snapshot_kind: text
 ---
@@ -19,15 +20,15 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                        ┌───────────────Confirm────────────────┐                                        
-                                        │                                      │                                        
-                                        │  Do you want to quit?                │                                        
-                                        │                                      │                                        
-                                        │                                      │                                        
-                                        │  [y] Confirm                         │                                        
-                                        │  [n] Cancel                          │                                        
-                                        │                                      │                                        
-                                        └──────────────────────────────────────┘                                        
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           

--- a/tui/tests/snapshots/editor_normal__quit_menu_open.snap
+++ b/tui/tests/snapshots/editor_normal__quit_menu_open.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/tests/editor_normal.rs
+assertion_line: 31
 expression: text
 snapshot_kind: text
 ---
@@ -18,17 +19,17 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
+                                      ┌─────────────────Notebook─────────────────┐                                      
+                                      │                                          │                                      
+                                      │  Leave the notebook?                     │                                      
+                                      │                                          │                                      
+                                      │                                          │                                      
+                                      │                                          │                                      
+                                      │  [m] Back to menu                        │                                      
+                                      │  [q] Quit                                │                                      
+                                      │  [Esc] Cancel                            │                                      
+                                      │                                          │                                      
+                                      └──────────────────────────────────────────┘                                      
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           


### PR DESCRIPTION
## Summary
- add an in-app quit menu for notebook escape flow
- update entry quit flow and hide quit options in wasm builds
- include snapshots and tests covering new dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quit menu when exiting a notebook: pressing Esc opens a dialog with [m] Back to menu/entry, [Esc] Cancel, and (non-web) [q] Quit; may save before opening from the editor.
  * Replaced single-step quit with a two-step flow via the quit menu for clearer choices.
  * On web builds, removed Quit from the entry menu and omit [q] in the quit dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->