### PR TITLE
Add manual deploy workflow for glues site

### DIFF
--- a/.github/workflows/deploy-glues-site.yml
+++ b/.github/workflows/deploy-glues-site.yml
@@ -11,7 +11,7 @@ jobs:
     name: Deploy glues web bundle
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout glues
@@ -36,27 +36,25 @@ jobs:
           cd tui/web
           trunk build --release
 
-      - name: Checkout gluesql.github.io
-        uses: actions/checkout@v4
-        with:
-          repository: gluesql/gluesql.github.io
-          path: site
+      - name: Clone gluesql.org
+        run: git clone https://github.com/gluesql/gluesql.github.io.git
 
-      - name: Update deployed bundle
+      - name: Prepare glues bundle
         run: |
-          rm -rf site/glues
-          mkdir -p site/glues
-          cp -R tui/web/dist/. site/glues/
+          rm -rf gluesql.github.io/glues
+          mkdir -p gluesql.github.io/glues
+          cp -R tui/web/dist/. gluesql.github.io/glues/
 
-      - name: Commit and push updates
+      - name: Configure git user
         run: |
-          cd site
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "No changes to deploy."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.email "taehoon.moon@outlook.com"
+          git config --global user.name "Taehoon Moon (Bot)"
+
+      - name: Commit and deploy
+        run: |
+          cd gluesql.github.io
           git add glues
-          git commit -m "Deploy glues web bundle $(date -u '+%Y-%m-%d %H:%M:%S %Z')"
-          git push
+          git diff-index --quiet HEAD || (
+            git commit -m "Deploy glues web bundle" &&
+            git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
+          )

--- a/.github/workflows/deploy-glues-site.yml
+++ b/.github/workflows/deploy-glues-site.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build web bundle
         run: |
           cd tui/web
-          trunk build --release
+          trunk build --release --public-url /glues/
 
       - name: Clone gluesql.org
         run: git clone https://github.com/gluesql/gluesql.github.io.git

--- a/.github/workflows/deploy-glues-site.yml
+++ b/.github/workflows/deploy-glues-site.yml
@@ -1,0 +1,62 @@
+name: Deploy glues Web
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy:
+    name: Deploy glues web bundle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout glues
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Ensure wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install trunk
+        run: cargo install trunk --locked --force
+
+      - name: Build web bundle
+        run: |
+          cd tui/web
+          trunk build --release
+
+      - name: Checkout gluesql.github.io
+        uses: actions/checkout@v4
+        with:
+          repository: gluesql/gluesql.github.io
+          path: site
+
+      - name: Update deployed bundle
+        run: |
+          rm -rf site/glues
+          mkdir -p site/glues
+          cp -R tui/web/dist/. site/glues/
+
+      - name: Commit and push updates
+        run: |
+          cd site
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to deploy."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add glues
+          git commit -m "Deploy glues web bundle $(date -u '+%Y-%m-%d %H:%M:%S %Z')"
+          git push


### PR DESCRIPTION
## Summary
- add a manually triggered workflow to build the web bundle
- publish the bundle into gluesql.github.io/glues via actions checkout and copy

## Testing
- not run (workflow change only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added an automated deployment workflow for the glues web site with a manual trigger to build and publish the web bundle.
  - Uses the Rust/wasm toolchain, caches build artifacts, and installs required tooling to speed runs.
  - Deploys updates to the site repository only when changes are detected, committing and pushing with secured bot credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->