### PR TITLE
Remove CLI theme argument now that themes switch in-app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,6 @@ version = "0.7.0"
 dependencies = [
  "arboard",
  "async-recursion",
- "clap",
  "color-eyre",
  "console_error_panic_hook",
  "glues-core",

--- a/README.md
+++ b/README.md
@@ -77,11 +77,8 @@ To produce a static bundle instead, run `trunk build --release` from the same di
 ### Theme Presets
 
 Glues includes several built-in color schemes. The application starts with the
-`dark` palette by default, but you can switch presets with the `--theme` option:
-
-```bash
-glues --theme pastel
-```
+`dark` palette by default, and you can switch presets at runtime through the
+Theme menu in the entry dialog.
 
 The built-in themes are:
 

--- a/bin/glues/src/main.rs
+++ b/bin/glues/src/main.rs
@@ -2,7 +2,7 @@ use {
     clap::{Parser, Subcommand},
     color_eyre::Result,
     glues_server::ServerArgs,
-    glues_tui::cli::{self, TuiArgs},
+    glues_tui::cli,
 };
 
 #[derive(Parser)]
@@ -14,9 +14,6 @@ use {
     propagate_version = true
 )]
 struct Cli {
-    #[command(flatten)]
-    tui: TuiArgs,
-
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -29,10 +26,10 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let Cli { tui, command } = Cli::parse();
+    let Cli { command } = Cli::parse();
 
     match command {
         Some(Command::Server(args)) => glues_server::run(args).await,
-        None => cli::run(tui).await,
+        None => cli::run().await,
     }
 }

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -21,7 +21,6 @@ color-eyre = "0.6.3"
 tui-big-text = "0.7.0"
 tui-textarea = { version = "0.7.0", default-features = false, features = ["ratatui"] }
 textwrap = "0.16"
-clap = { version = "4.5.4", features = ["derive"] }
 
 [features]
 default = ["cli"]

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -2,60 +2,15 @@
 
 use {
     crate::{App, config, logger, theme},
-    clap::{Args, Parser, ValueEnum},
     color_eyre::Result,
 };
 
-#[derive(Clone, Copy, ValueEnum)]
-pub enum ThemeArg {
-    Dark,
-    Light,
-    Pastel,
-    Sunrise,
-    Midnight,
-    Forest,
-}
-
-#[derive(Clone, Default, Args)]
-pub struct TuiArgs {
-    #[arg(long, value_enum)]
-    pub theme: Option<ThemeArg>,
-}
-
-#[derive(Parser)]
-#[command(author, version, about)]
-struct Cli {
-    #[command(flatten)]
-    args: TuiArgs,
-}
-
-pub fn parse_args() -> TuiArgs {
-    Cli::parse().args
-}
-
-impl From<ThemeArg> for theme::ThemeId {
-    fn from(arg: ThemeArg) -> Self {
-        match arg {
-            ThemeArg::Dark => theme::ThemeId::Dark,
-            ThemeArg::Light => theme::ThemeId::Light,
-            ThemeArg::Pastel => theme::ThemeId::Pastel,
-            ThemeArg::Sunrise => theme::ThemeId::Sunrise,
-            ThemeArg::Midnight => theme::ThemeId::Midnight,
-            ThemeArg::Forest => theme::ThemeId::Forest,
-        }
-    }
-}
-
-pub async fn run(args: TuiArgs) -> Result<()> {
+pub async fn run() -> Result<()> {
     config::init().await;
 
-    let saved_theme = config::get(config::LAST_THEME)
+    let theme_id = config::get(config::LAST_THEME)
         .await
-        .and_then(|value| value.parse().ok());
-    let theme_id = args
-        .theme
-        .map(Into::into)
-        .or(saved_theme)
+        .and_then(|value| value.parse().ok())
         .unwrap_or(theme::ThemeId::Dark);
 
     theme::set_theme(theme_id);
@@ -71,5 +26,5 @@ pub async fn run(args: TuiArgs) -> Result<()> {
 }
 
 pub async fn run_cli() -> Result<()> {
-    run(parse_args()).await
+    run().await
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -4,7 +4,7 @@ use glues_tui::cli;
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
-    cli::run_cli().await
+    cli::run().await
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
## Summary
- drop the TUI `--theme` flag now that themes are switchable at runtime
- simplify CLI entrypoint to rely on saved config and update docs accordingly
- remove the unused Clap dependency from the TUI crate

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
