### PR TITLE
Speed up Trunk installation in CI

### DIFF
--- a/.github/workflows/deploy-glues-site.yml
+++ b/.github/workflows/deploy-glues-site.yml
@@ -29,7 +29,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install trunk
-        run: cargo install trunk --locked --force
+        uses: jetli/trunk-action@v0.5.0
+        with:
+          version: latest
 
       - name: Build web bundle
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,9 @@ jobs:
       - name: Check wasm32 target
         run: cargo check --target wasm32-unknown-unknown -p glues-tui
       - name: Install trunk
-        run: cargo install trunk --locked --force
+        uses: jetli/trunk-action@v0.5.0
+        with:
+          version: latest
       - name: Build web bundle
         run: |
           cd tui/web


### PR DESCRIPTION
## Summary
- replace manual `cargo install trunk` steps with jetli/trunk-action to use prebuilt binaries
- apply the faster installation path to both CI wasm build and manual deploy workflows

## Testing
- none (workflow-only change)
