### PR TITLE
Fix deploy workflow title casing

### DIFF
--- a/.github/workflows/deploy-glues-site.yml
+++ b/.github/workflows/deploy-glues-site.yml
@@ -1,4 +1,4 @@
-name: Deploy glues Web
+name: Deploy Glues Web
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- capitalize the manual deploy workflow name for consistency

## Testing
- none (workflow-only change)
