### PR TITLE
Replace unwraps with expects

### DIFF
--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -55,7 +55,7 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .execute(storage)
         .await?
         .select()
-        .unwrap()
+        .expect("Meta query must yield a result set")
         .count()
         == 0;
 
@@ -75,7 +75,7 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .execute(storage)
         .await?
         .select()
-        .unwrap()
+        .expect("Directory query must yield a result set")
         .count()
         == 0;
 
@@ -95,9 +95,9 @@ pub async fn setup(storage: &mut Storage) -> Result<DirectoryId> {
         .execute(storage)
         .await?
         .select()
-        .unwrap()
+        .expect("Directory query must yield a result set")
         .next()
-        .unwrap()
+        .expect("Root directory row should exist")
         .get("id")
         .map(Deref::deref)
         .map(Into::into)

--- a/core/tests/backend.rs
+++ b/core/tests/backend.rs
@@ -5,21 +5,29 @@ use std::sync::mpsc::channel;
 #[tokio::test]
 async fn memory_backend_operations() {
     let (tx, _rx) = channel();
-    let mut db = Db::memory(tx).await.unwrap();
+    let mut db = Db::memory(tx)
+        .await
+        .expect("in-memory backend should initialize");
 
     let root_id = db.root_id();
-    let root = db.fetch_directory(root_id.clone()).await.unwrap();
+    let root = db
+        .fetch_directory(root_id.clone())
+        .await
+        .expect("backend should fetch root directory");
     assert_eq!(root.name, "Notes");
 
     // add directory
     let dir = db
         .add_directory(root_id.clone(), "Work".to_owned())
         .await
-        .unwrap();
+        .expect("backend should add directory");
     assert_eq!(dir.name, "Work");
 
     // fetch directories
-    let dirs = db.fetch_directories(root_id.clone()).await.unwrap();
+    let dirs = db
+        .fetch_directories(root_id.clone())
+        .await
+        .expect("backend should list directories");
     assert_eq!(dirs.len(), 1);
     assert_eq!(dirs[0].name, "Work");
 
@@ -27,47 +35,69 @@ async fn memory_backend_operations() {
     let note = db
         .add_note(dir.id.clone(), "Todo".to_owned())
         .await
-        .unwrap();
+        .expect("backend should add note");
     assert_eq!(note.name, "Todo");
 
     // fetch notes
-    let notes = db.fetch_notes(dir.id.clone()).await.unwrap();
+    let notes = db
+        .fetch_notes(dir.id.clone())
+        .await
+        .expect("backend should list notes in directory");
     assert_eq!(notes.len(), 1);
     assert_eq!(notes[0].name, "Todo");
 
     // update note content
     db.update_note_content(note.id.clone(), "hello".to_owned())
         .await
-        .unwrap();
-    let content = db.fetch_note_content(note.id.clone()).await.unwrap();
+        .expect("backend should update note content");
+    let content = db
+        .fetch_note_content(note.id.clone())
+        .await
+        .expect("backend should fetch note content");
     assert_eq!(content, "hello");
 
     // rename note
     db.rename_note(note.id.clone(), "Hello".to_owned())
         .await
-        .unwrap();
-    let notes = db.fetch_notes(dir.id.clone()).await.unwrap();
+        .expect("backend should rename note");
+    let notes = db
+        .fetch_notes(dir.id.clone())
+        .await
+        .expect("backend should list notes after rename");
     assert_eq!(notes[0].name, "Hello");
 
     // move note to root
     db.move_note(note.id.clone(), root_id.clone())
         .await
-        .unwrap();
-    let notes_root = db.fetch_notes(root_id.clone()).await.unwrap();
+        .expect("backend should move note");
+    let notes_root = db
+        .fetch_notes(root_id.clone())
+        .await
+        .expect("backend should list root notes");
     assert_eq!(notes_root.len(), 1);
 
     // remove note
-    db.remove_note(note.id.clone()).await.unwrap();
-    let notes_root = db.fetch_notes(root_id.clone()).await.unwrap();
+    db.remove_note(note.id.clone())
+        .await
+        .expect("backend should remove note");
+    let notes_root = db
+        .fetch_notes(root_id.clone())
+        .await
+        .expect("backend should list notes after removal");
     assert!(notes_root.is_empty());
 
     // remove directory
-    db.remove_directory(dir.id.clone()).await.unwrap();
-    let dirs = db.fetch_directories(root_id.clone()).await.unwrap();
+    db.remove_directory(dir.id.clone())
+        .await
+        .expect("backend should remove directory");
+    let dirs = db
+        .fetch_directories(root_id.clone())
+        .await
+        .expect("backend should list directories after removal");
     assert!(dirs.is_empty());
 
     // logging
     db.log("test".to_owned(), "message".to_owned())
         .await
-        .unwrap();
+        .expect("backend should append log entry");
 }

--- a/tui/src/config.rs
+++ b/tui/src/config.rs
@@ -43,7 +43,7 @@ pub(crate) mod platform {
         let path = home_dir()
             .unwrap_or(std::env::current_dir().expect("failed to get current directory"))
             .join(PATH);
-        let storage = CsvStorage::new(path).unwrap();
+        let storage = CsvStorage::new(path).expect("failed to open CSV config storage");
 
         Glue::new(storage)
     }
@@ -57,7 +57,7 @@ pub(crate) mod platform {
             .add_column("value TEXT NOT NULL")
             .execute(&mut glue)
             .await
-            .unwrap();
+            .expect("config table creation should succeed");
 
         for (key, value) in DEFAULTS {
             let _ = table("config")
@@ -78,7 +78,7 @@ pub(crate) mod platform {
             .set("value", text(value))
             .execute(&mut glue)
             .await
-            .unwrap();
+            .expect("config update should succeed");
     }
 
     pub async fn get(key: &str) -> Option<String> {
@@ -129,7 +129,7 @@ pub(crate) mod platform {
             .add_column("value TEXT NOT NULL")
             .execute(&mut glue)
             .await
-            .unwrap();
+            .expect("config table creation should succeed");
 
         for (key, value) in DEFAULTS {
             let _ = table("config")
@@ -150,7 +150,7 @@ pub(crate) mod platform {
             .set("value", text(value))
             .execute(&mut glue)
             .await
-            .unwrap();
+            .expect("config update should succeed");
     }
 
     pub async fn get(key: &str) -> Option<String> {

--- a/tui/src/logger.rs
+++ b/tui/src/logger.rs
@@ -21,7 +21,7 @@ pub async fn init() {
             .add_column("message TEXT")
             .execute(&mut glue)
             .await
-            .unwrap();
+            .expect("logger should create logs table");
     }
 }
 
@@ -38,7 +38,7 @@ pub async fn log(message: &str) {
             .values(vec![vec![text(message)]])
             .execute(&mut glue)
             .await
-            .unwrap();
+            .expect("logger should insert log entry");
     }
 }
 


### PR DESCRIPTION
## Summary
- swap `.unwrap()` calls for `.expect()` with context-aware messages in core schema setup and config/logger paths
- adjust integration tests to provide clearer failure context when backend/proxy operations fail

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Refactor
  - Improved error diagnostics across the app by replacing generic panics with descriptive messages, aiding troubleshooting without altering normal behavior.
- Bug Fixes
  - Clearer failure feedback during startup, configuration updates, logging, and network/proxy operations.
- Tests
  - Enhanced test stability and readability with explicit error messaging on failures.
- Chores
  - Standardized error handling patterns for consistency across components.

Note: No functional changes; behavior remains the same under normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->