### PR TITLE
Apply theme color to note tree note icon

### DIFF
--- a/tui/src/views/body/notebook/note_tree.rs
+++ b/tui/src/views/body/notebook/note_tree.rs
@@ -52,7 +52,7 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
                     let pad = depth * 2;
                     Line::from(vec![
                         format!("{:pad$}", "").into(),
-                        Span::raw(NOTE_SYMBOL).dim(),
+                        Span::raw(NOTE_SYMBOL).fg(THEME.text_secondary),
                         Span::raw(&note.name),
                     ])
                 }


### PR DESCRIPTION
## Summary
- apply the theme's secondary text color to note icons instead of using dim so web renders cleanly

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
