### PR TITLE
Sync web yank with browser clipboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "gluesql",
  "home",
  "insta",
+ "js-sys",
  "ratatui",
  "ratzilla",
  "textwrap",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -61,4 +61,7 @@ web-sys = { version = "0.3", features = [
     "KeyboardEvent",
     "Window",
     "CompositionEvent",
+    "Navigator",
+    "Clipboard",
 ] }
+js-sys = "0.3"

--- a/tui/src/context/notebook.rs
+++ b/tui/src/context/notebook.rs
@@ -372,6 +372,9 @@ impl NotebookContext {
             let _ = clipboard.set_text(&text);
         }
 
+        #[cfg(target_arch = "wasm32")]
+        crate::web::copy_to_clipboard(&text);
+
         self.yank = Some(text);
     }
 


### PR DESCRIPTION
## Summary
- add a wasm-only helper that writes yank text to `navigator.clipboard`
- call the helper when notebook yank buffers update so web builds copy to the OS clipboard as well

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web (WASM) builds now support copying yanked text to the system clipboard using the browser’s Clipboard API, enabling seamless copy operations in the web UI.

* **Chores**
  * Updated web platform dependencies to enable clipboard functionality in WASM environments.

* **Refactor**
  * Adjusted internal web rendering error handling to return and propagate errors more cleanly (no impact on public behavior).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->