### PR TITLE
Add notebook gateway and scroll snapshot tests

### DIFF
--- a/tui/tests/editor_normal.rs
+++ b/tui/tests/editor_normal.rs
@@ -4,6 +4,7 @@ use tester::Tester;
 
 use color_eyre::Result;
 use glues_tui::input::KeyCode;
+use tui_textarea::TextArea;
 
 #[tokio::test]
 async fn quits_on_esc_then_q() -> Result<()> {
@@ -104,4 +105,89 @@ async fn delete_line_with_dd() -> Result<()> {
     snap!(t, "after_delete_line");
 
     Ok(())
+}
+
+#[tokio::test]
+async fn gateway_moves_cursor_to_top() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    seed_long_note(&mut t);
+    t.draw()?;
+
+    // Move to bottom so the gateway jump visibly changes the view.
+    t.press('G').await;
+
+    // First 'g' enters gateway mode.
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "gateway_prompt");
+
+    // Second 'g' jumps to the top line.
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "gateway_move_top");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn scroll_commands_update_view() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    seed_long_note(&mut t);
+    t.draw()?;
+
+    // Start near the middle of the document.
+    for _ in 0..20 {
+        t.press('j').await;
+    }
+
+    t.press('z').await;
+    t.draw()?;
+    snap!(t, "scroll_prompt");
+
+    t.press('t').await;
+    t.draw()?;
+    snap!(t, "scroll_jump_top");
+
+    // Jump to bottom and use 'zb'.
+    t.press('G').await;
+    t.press('z').await;
+    t.press('b').await;
+    t.draw()?;
+    snap!(t, "scroll_jump_bottom");
+
+    // Move back toward the middle and center with 'z.'.
+    for _ in 0..15 {
+        t.press('k').await;
+    }
+    t.press('z').await;
+    t.press('.').await;
+    t.draw()?;
+    snap!(t, "scroll_jump_center");
+
+    Ok(())
+}
+
+fn seed_long_note(tester: &mut Tester) {
+    let lines: Vec<String> = (1..=60)
+        .map(|i| format!("Line {i:02} — the quick brown fox jumps over the lazy dog."))
+        .collect();
+
+    let context = tester.app.context_mut();
+    if let Some(note_id) = context
+        .notebook
+        .get_opened_note()
+        .map(|note| note.id.clone())
+    {
+        *context.notebook.get_editor_mut() = TextArea::from(lines);
+
+        if let Some(editor) = context.notebook.editors.get_mut(&note_id) {
+            editor.dirty = false;
+        }
+    }
 }

--- a/tui/tests/snapshots/editor_normal__gateway_move_top.snap
+++ b/tui/tests/snapshots/editor_normal__gateway_move_top.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/editor_normal.rs
+assertion_line: 130
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐  1 Line 01 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐  2 Line 02 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  3 Line 03 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  4 Line 04 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  5 Line 05 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  6 Line 06 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  7 Line 07 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  8 Line 08 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  9 Line 09 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 10 Line 10 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 11 Line 11 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 12 Line 12 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 13 Line 13 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 14 Line 14 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 15 Line 15 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 16 Line 16 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 17 Line 17 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 18 Line 18 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 19 Line 19 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 20 Line 20 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_normal__gateway_prompt.snap
+++ b/tui/tests/snapshots/editor_normal__gateway_prompt.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/editor_normal.rs
+assertion_line: 125
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode - gateway                                                              [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 40 Line 40 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 41 Line 41 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 42 Line 42 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 43 Line 43 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 44 Line 44 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 45 Line 45 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 46 Line 46 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 47 Line 47 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 48 Line 48 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 49 Line 49 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 50 Line 50 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 51 Line 51 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 52 Line 52 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 53 Line 53 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 54 Line 54 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_normal__scroll_jump_bottom.snap
+++ b/tui/tests/snapshots/editor_normal__scroll_jump_bottom.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/editor_normal.rs
+assertion_line: 162
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 40 Line 40 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 41 Line 41 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 42 Line 42 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 43 Line 43 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 44 Line 44 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 45 Line 45 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 46 Line 46 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 47 Line 47 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 48 Line 48 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 49 Line 49 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 50 Line 50 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 51 Line 51 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 52 Line 52 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 53 Line 53 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 54 Line 54 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_normal__scroll_jump_center.snap
+++ b/tui/tests/snapshots/editor_normal__scroll_jump_center.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/editor_normal.rs
+assertion_line: 171
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 40 Line 40 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 41 Line 41 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 42 Line 42 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 43 Line 43 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 44 Line 44 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 45 Line 45 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 46 Line 46 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 47 Line 47 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 48 Line 48 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 49 Line 49 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 50 Line 50 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 51 Line 51 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 52 Line 52 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 53 Line 53 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 54 Line 54 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_normal__scroll_jump_top.snap
+++ b/tui/tests/snapshots/editor_normal__scroll_jump_top.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/editor_normal.rs
+assertion_line: 155
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 40 Line 40 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 41 Line 41 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 42 Line 42 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 43 Line 43 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 44 Line 44 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 45 Line 45 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 46 Line 46 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 47 Line 47 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 48 Line 48 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 49 Line 49 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 50 Line 50 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 51 Line 51 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 52 Line 52 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 53 Line 53 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 54 Line 54 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_normal__scroll_prompt.snap
+++ b/tui/tests/snapshots/editor_normal__scroll_prompt.snap
@@ -1,33 +1,13 @@
 ---
 source: tui/tests/editor_normal.rs
-assertion_line: 151
+assertion_line: 152
 expression: text
 snapshot_kind: text
 ---
  Note 'Sample Note' normal mode - scroll                                                               [?] Show keymap 
 [Browser]                                   ▐ 󱇗 Sample Note                                                             
- 󰝰 Notes                                    ▐  1 Line 01 — the quick brown fox jumps over the lazy dog.                 
-   󱇗 Sample Note                            ▐  2 Line 02 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐  3 Line 03 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐  4 Line 04 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐  5 Line 05 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐  6 Line 06 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐  7 Line 07 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐  8 Line 08 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐  9 Line 09 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 10 Line 10 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 11 Line 11 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 12 Line 12 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 13 Line 13 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 14 Line 14 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 15 Line 15 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 16 Line 16 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 17 Line 17 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 18 Line 18 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 19 Line 19 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 20 Line 20 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+ 󰝰 Notes                                    ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
@@ -43,4 +23,24 @@ snapshot_kind: text
                                             ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 40 Line 40 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 41 Line 41 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 42 Line 42 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 43 Line 43 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 44 Line 44 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 45 Line 45 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 46 Line 46 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 47 Line 47 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 48 Line 48 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 49 Line 49 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 50 Line 50 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 51 Line 51 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 52 Line 52 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 53 Line 53 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 54 Line 54 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_normal__scroll_prompt.snap
+++ b/tui/tests/snapshots/editor_normal__scroll_prompt.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/editor_normal.rs
+assertion_line: 151
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode - scroll                                                               [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐  1 Line 01 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐  2 Line 02 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  3 Line 03 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  4 Line 04 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  5 Line 05 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  6 Line 06 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  7 Line 07 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  8 Line 08 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  9 Line 09 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 10 Line 10 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 11 Line 11 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 12 Line 12 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 13 Line 13 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 14 Line 14 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 15 Line 15 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 16 Line 16 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 17 Line 17 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 18 Line 18 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 19 Line 19 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 20 Line 20 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 


### PR DESCRIPTION
## Summary
- add gateway (gg) navigation coverage to the notebook editor test
- capture scroll prompts and viewport movement snapshots for zt/zb/z.
- populate the long-note fixture through editor keystrokes so tests avoid touching context

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
