### PR TITLE
Add IndexedDB help text to web dialog

### DIFF
--- a/tui/src/views/dialog/help.rs
+++ b/tui/src/views/dialog/help.rs
@@ -39,6 +39,10 @@ pub fn draw(frame: &mut Frame) {
                 Line::raw("Volatile in-memory storage that resets when Glues exits."),
                 Line::raw("Great for quick scratch notes or testing."),
                 Line::raw(""),
+                Line::from("IndexedDB".fg(THEME.accent_text).bg(THEME.accent)),
+                Line::raw("Keeps notes in the browser across refreshes."),
+                Line::raw("Pick a namespace to isolate multiple notebooks (default: `glues`)."),
+                Line::raw(""),
                 Line::from("Proxy".fg(THEME.accent_text).bg(THEME.accent)),
                 Line::raw("Bridge to a Glues proxy server for persistence."),
                 Line::raw(


### PR DESCRIPTION
## Summary
- include the IndexedDB option in the web help overlay so the browser build lists every storage backend

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web (wasm32): Introduced an IndexedDB storage option, providing data persistence across page refreshes and namespace isolation (default namespace “glues”).
* **Documentation**
  * Updated the Web help dialog to include the new IndexedDB storage option with descriptive details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->