### PR TITLE
Document local storage for agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .glues
 /target
 tui/web/dist/
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,6 @@
 
 ## GitHub Issue Tips
 - Compose multi-line bodies via a heredoc and pass `--body-file` to `gh issue create` / `gh issue edit` to avoid shell parsing issues.
+
+## Personal Instructions
+- Store collaborator-specific guidance in `AGENTS.local.md`. This file is gitignored and should remain local to each contributor.


### PR DESCRIPTION
## Summary
- reference `AGENTS.local.md` for collaborator-specific guidance
- ignore the personal instructions file in git

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on storing collaborator-specific “Personal Instructions” locally, with a new subsection under GitHub Issue Tips.
  * Clarifies that personal notes should be kept out of the repository and maintained per contributor.

* **Chores**
  * Updated version control ignore rules to exclude a local, contributor-specific notes file, preventing accidental commits of personal instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->