### PR TITLE
Document Trunk build step for wasm changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@
 - Finish by updating coverage (`cargo coverage --no-report`).
 - Default to driving scenarios through real input; avoid mutating internal context (`App::context_mut`) from tests unless absolutely necessary.
 
+## Web Builds
+- When modifying WASM-specific code, run `trunk build --release` to verify the web bundle.
+
 ## GitHub Issue Tips
 - Compose multi-line bodies via a heredoc and pass `--body-file` to `gh issue create` / `gh issue edit` to avoid shell parsing issues.
 


### PR DESCRIPTION
## Summary
- add a Web Builds section to AGENTS.md
- require running `trunk build --release` when touching wasm-specific code

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
