### PR TITLE
Import GitHub release notes

### DIFF
--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,4 +1,4 @@
 ## What's Changed
-* Migrate TUI implementation to Ratatui by @panarch in https://github.com/gluesql/glues/pull/1
+* Migrate TUI implementation to Ratatui by [@panarch](https://github.com/panarch) in [#1](https://github.com/gluesql/glues/pull/1)
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.2.2...v0.3.1

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,4 @@
+## What's Changed
+* Migrate TUI implementation to Ratatui by @panarch in https://github.com/gluesql/glues/pull/1
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.2.2...v0.3.1

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,0 +1,5 @@
+## What's Changed
+* Enable Link-Time Optimization for release build by @panarch in https://github.com/gluesql/glues/pull/5
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.3.1...v0.3.2

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,5 +1,5 @@
 ## What's Changed
-* Enable Link-Time Optimization for release build by @panarch in https://github.com/gluesql/glues/pull/5
+* Enable Link-Time Optimization for release build by [@panarch](https://github.com/panarch) in [#5](https://github.com/gluesql/glues/pull/5)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.3.1...v0.3.2

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,63 @@
+Glues is a Vim-inspired TUI note-taking app with Git and MongoDB support - privacy-focused and sync-enabled.
+I am excited to announce the release of Glues v0.4.0!
+This version brings significant new features and enhancements to improve your note-taking experience.
+
+# 🌊 New Features
+## 🚀 MongoDB Storage Support
+Added MongoDB note data storage support: You can now store your notes using MongoDB, offering centralized data management. This adds to our existing storage options:
+- **Instant**: Notes are maintained only while the app is open.
+- **Local**: Notes are stored locally without remote synchronization.
+- **Git**: Notes are stored locally and synchronized with a remote Git repository.
+- **MongoDB**: Notes are stored on a remote MongoDB database.
+<img width="433" alt="image" src="https://github.com/user-attachments/assets/38d73d28-9d94-4d20-baa9-42e3182f4f4b">
+
+
+## 💡 Vim-Inspired Features
+- **Added Vim-inspired commands**: I have integrated various Vim commands to enhance your editing experience. You can switch between normal and visual modes, and use common Vim commands for navigation and editing.
+- **Keymap Dialog**: Press Ctrl+h in any mode to open a keymap dialog showing available commands in the current mode.
+Editor Line Number Feature
+- **Toggle Line Numbers**: You can now display line numbers in the editor for easier navigation and reference.
+
+<img width="737" alt="image" src="https://github.com/user-attachments/assets/5e271c47-05c5-416d-b00d-503451c6677f">
+<img width="739" alt="image" src="https://github.com/user-attachments/assets/a73874fa-8122-49bf-b5ad-8fe888b5266c">
+<img width="757" alt="image" src="https://github.com/user-attachments/assets/9d45f5e8-2383-4f52-a9b8-6d1672a29ea3">
+<img width="732" alt="image" src="https://github.com/user-attachments/assets/62ca6a7b-0b64-4dcd-a3fb-2cfe60ee2745">
+
+
+# What's Changed
+* Add toggle line number feature to editor by @panarch in https://github.com/gluesql/glues/pull/6
+* Replace async runtime from async-io to tokio by @panarch in https://github.com/gluesql/glues/pull/7
+* Add MongoDB note data storage support by @panarch in https://github.com/gluesql/glues/pull/8
+* Update editor keymap dialog - remove Ctrl+H by @panarch in https://github.com/gluesql/glues/pull/9
+* Upgrade Ratatui version to 0.29 by @panarch in https://github.com/gluesql/glues/pull/10
+* Add multi-step up/down move support to note tree by @panarch in https://github.com/gluesql/glues/pull/11
+* Split NotebookState::consume into sub modules based on InnerState by @panarch in https://github.com/gluesql/glues/pull/12
+* Prevent root directory removal and renaming by @panarch in https://github.com/gluesql/glues/pull/13
+* Rename Editing{View,Edit}Mode to Editing{Normal,Insert}Mode by @panarch in https://github.com/gluesql/glues/pull/14
+* Add vim normal mode hjkl navigation support to editor by @panarch in https://github.com/gluesql/glues/pull/15
+* Simplify tui/ NotebookContext match codes by @panarch in https://github.com/gluesql/glues/pull/16
+* Simplify tui/ NotebookContext match codes by @panarch in https://github.com/gluesql/glues/pull/17
+* Prevent NumKey step appending overflow by @panarch in https://github.com/gluesql/glues/pull/18
+* Add normal mode b|e|w cursor word move key binding support by @panarch in https://github.com/gluesql/glues/pull/19
+* Update status bar layout: Move description to bottom, keymap to top by @panarch in https://github.com/gluesql/glues/pull/20
+* Change EntryState description by @panarch in https://github.com/gluesql/glues/pull/21
+* Add inserting new line above(O) & below(o) support by @panarch in https://github.com/gluesql/glues/pull/22
+* Add moving cursor to head(0) and end($) key bindings by @panarch in https://github.com/gluesql/glues/pull/23
+* Add entering insert mode key bindings: a, A and I by @panarch in https://github.com/gluesql/glues/pull/24
+* Add G key binding support: cursor to bottom or line number by @panarch in https://github.com/gluesql/glues/pull/25
+* Add gg key binding support: move cursor to top by @panarch in https://github.com/gluesql/glues/pull/26
+* Simplify core/ editing_normal_mode module codes by @panarch in https://github.com/gluesql/glues/pull/27
+* Update storage descriptions, by @panarch in https://github.com/gluesql/glues/pull/28
+* Add normal mode s, S and x key bindings by @panarch in https://github.com/gluesql/glues/pull/29
+* Add caret(^) key binding: move cursor to first non-blank char of the … by @panarch in https://github.com/gluesql/glues/pull/30
+* Add yank(y) and paste(p) key bindings by @panarch in https://github.com/gluesql/glues/pull/31
+* Implement line yank feature and apply to current yank transition by @panarch in https://github.com/gluesql/glues/pull/32
+* Add delete(d) key bindings: delete lines by @panarch in https://github.com/gluesql/glues/pull/33
+* Add undo(u) and redo(Ctrl+r) key bindings by @panarch in https://github.com/gluesql/glues/pull/34
+* Implement visual mode support to editor by @panarch in https://github.com/gluesql/glues/pull/35
+* Update Glues app description - add Vim-inspired by @panarch in https://github.com/gluesql/glues/pull/36
+* Simplify tui/ transitions module codes by @panarch in https://github.com/gluesql/glues/pull/37
+* Add vim keymap dialogs - Ctrl+h to open by @panarch in https://github.com/gluesql/glues/pull/38
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.3.2...v0.4.0

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -25,39 +25,39 @@ Editor Line Number Feature
 
 
 # What's Changed
-* Add toggle line number feature to editor by @panarch in https://github.com/gluesql/glues/pull/6
-* Replace async runtime from async-io to tokio by @panarch in https://github.com/gluesql/glues/pull/7
-* Add MongoDB note data storage support by @panarch in https://github.com/gluesql/glues/pull/8
-* Update editor keymap dialog - remove Ctrl+H by @panarch in https://github.com/gluesql/glues/pull/9
-* Upgrade Ratatui version to 0.29 by @panarch in https://github.com/gluesql/glues/pull/10
-* Add multi-step up/down move support to note tree by @panarch in https://github.com/gluesql/glues/pull/11
-* Split NotebookState::consume into sub modules based on InnerState by @panarch in https://github.com/gluesql/glues/pull/12
-* Prevent root directory removal and renaming by @panarch in https://github.com/gluesql/glues/pull/13
-* Rename Editing{View,Edit}Mode to Editing{Normal,Insert}Mode by @panarch in https://github.com/gluesql/glues/pull/14
-* Add vim normal mode hjkl navigation support to editor by @panarch in https://github.com/gluesql/glues/pull/15
-* Simplify tui/ NotebookContext match codes by @panarch in https://github.com/gluesql/glues/pull/16
-* Simplify tui/ NotebookContext match codes by @panarch in https://github.com/gluesql/glues/pull/17
-* Prevent NumKey step appending overflow by @panarch in https://github.com/gluesql/glues/pull/18
-* Add normal mode b|e|w cursor word move key binding support by @panarch in https://github.com/gluesql/glues/pull/19
-* Update status bar layout: Move description to bottom, keymap to top by @panarch in https://github.com/gluesql/glues/pull/20
-* Change EntryState description by @panarch in https://github.com/gluesql/glues/pull/21
-* Add inserting new line above(O) & below(o) support by @panarch in https://github.com/gluesql/glues/pull/22
-* Add moving cursor to head(0) and end($) key bindings by @panarch in https://github.com/gluesql/glues/pull/23
-* Add entering insert mode key bindings: a, A and I by @panarch in https://github.com/gluesql/glues/pull/24
-* Add G key binding support: cursor to bottom or line number by @panarch in https://github.com/gluesql/glues/pull/25
-* Add gg key binding support: move cursor to top by @panarch in https://github.com/gluesql/glues/pull/26
-* Simplify core/ editing_normal_mode module codes by @panarch in https://github.com/gluesql/glues/pull/27
-* Update storage descriptions, by @panarch in https://github.com/gluesql/glues/pull/28
-* Add normal mode s, S and x key bindings by @panarch in https://github.com/gluesql/glues/pull/29
-* Add caret(^) key binding: move cursor to first non-blank char of the … by @panarch in https://github.com/gluesql/glues/pull/30
-* Add yank(y) and paste(p) key bindings by @panarch in https://github.com/gluesql/glues/pull/31
-* Implement line yank feature and apply to current yank transition by @panarch in https://github.com/gluesql/glues/pull/32
-* Add delete(d) key bindings: delete lines by @panarch in https://github.com/gluesql/glues/pull/33
-* Add undo(u) and redo(Ctrl+r) key bindings by @panarch in https://github.com/gluesql/glues/pull/34
-* Implement visual mode support to editor by @panarch in https://github.com/gluesql/glues/pull/35
-* Update Glues app description - add Vim-inspired by @panarch in https://github.com/gluesql/glues/pull/36
-* Simplify tui/ transitions module codes by @panarch in https://github.com/gluesql/glues/pull/37
-* Add vim keymap dialogs - Ctrl+h to open by @panarch in https://github.com/gluesql/glues/pull/38
+* Add toggle line number feature to editor by [@panarch](https://github.com/panarch) in [#6](https://github.com/gluesql/glues/pull/6)
+* Replace async runtime from async-io to tokio by [@panarch](https://github.com/panarch) in [#7](https://github.com/gluesql/glues/pull/7)
+* Add MongoDB note data storage support by [@panarch](https://github.com/panarch) in [#8](https://github.com/gluesql/glues/pull/8)
+* Update editor keymap dialog - remove Ctrl+H by [@panarch](https://github.com/panarch) in [#9](https://github.com/gluesql/glues/pull/9)
+* Upgrade Ratatui version to 0.29 by [@panarch](https://github.com/panarch) in [#10](https://github.com/gluesql/glues/pull/10)
+* Add multi-step up/down move support to note tree by [@panarch](https://github.com/panarch) in [#11](https://github.com/gluesql/glues/pull/11)
+* Split NotebookState::consume into sub modules based on InnerState by [@panarch](https://github.com/panarch) in [#12](https://github.com/gluesql/glues/pull/12)
+* Prevent root directory removal and renaming by [@panarch](https://github.com/panarch) in [#13](https://github.com/gluesql/glues/pull/13)
+* Rename Editing{View,Edit}Mode to Editing{Normal,Insert}Mode by [@panarch](https://github.com/panarch) in [#14](https://github.com/gluesql/glues/pull/14)
+* Add vim normal mode hjkl navigation support to editor by [@panarch](https://github.com/panarch) in [#15](https://github.com/gluesql/glues/pull/15)
+* Simplify tui/ NotebookContext match codes by [@panarch](https://github.com/panarch) in [#16](https://github.com/gluesql/glues/pull/16)
+* Simplify tui/ NotebookContext match codes by [@panarch](https://github.com/panarch) in [#17](https://github.com/gluesql/glues/pull/17)
+* Prevent NumKey step appending overflow by [@panarch](https://github.com/panarch) in [#18](https://github.com/gluesql/glues/pull/18)
+* Add normal mode b|e|w cursor word move key binding support by [@panarch](https://github.com/panarch) in [#19](https://github.com/gluesql/glues/pull/19)
+* Update status bar layout: Move description to bottom, keymap to top by [@panarch](https://github.com/panarch) in [#20](https://github.com/gluesql/glues/pull/20)
+* Change EntryState description by [@panarch](https://github.com/panarch) in [#21](https://github.com/gluesql/glues/pull/21)
+* Add inserting new line above(O) & below(o) support by [@panarch](https://github.com/panarch) in [#22](https://github.com/gluesql/glues/pull/22)
+* Add moving cursor to head(0) and end($) key bindings by [@panarch](https://github.com/panarch) in [#23](https://github.com/gluesql/glues/pull/23)
+* Add entering insert mode key bindings: a, A and I by [@panarch](https://github.com/panarch) in [#24](https://github.com/gluesql/glues/pull/24)
+* Add G key binding support: cursor to bottom or line number by [@panarch](https://github.com/panarch) in [#25](https://github.com/gluesql/glues/pull/25)
+* Add gg key binding support: move cursor to top by [@panarch](https://github.com/panarch) in [#26](https://github.com/gluesql/glues/pull/26)
+* Simplify core/ editing_normal_mode module codes by [@panarch](https://github.com/panarch) in [#27](https://github.com/gluesql/glues/pull/27)
+* Update storage descriptions, by [@panarch](https://github.com/panarch) in [#28](https://github.com/gluesql/glues/pull/28)
+* Add normal mode s, S and x key bindings by [@panarch](https://github.com/panarch) in [#29](https://github.com/gluesql/glues/pull/29)
+* Add caret(^) key binding: move cursor to first non-blank char of the … by [@panarch](https://github.com/panarch) in [#30](https://github.com/gluesql/glues/pull/30)
+* Add yank(y) and paste(p) key bindings by [@panarch](https://github.com/panarch) in [#31](https://github.com/gluesql/glues/pull/31)
+* Implement line yank feature and apply to current yank transition by [@panarch](https://github.com/panarch) in [#32](https://github.com/gluesql/glues/pull/32)
+* Add delete(d) key bindings: delete lines by [@panarch](https://github.com/panarch) in [#33](https://github.com/gluesql/glues/pull/33)
+* Add undo(u) and redo(Ctrl+r) key bindings by [@panarch](https://github.com/panarch) in [#34](https://github.com/gluesql/glues/pull/34)
+* Implement visual mode support to editor by [@panarch](https://github.com/panarch) in [#35](https://github.com/gluesql/glues/pull/35)
+* Update Glues app description - add Vim-inspired by [@panarch](https://github.com/panarch) in [#36](https://github.com/gluesql/glues/pull/36)
+* Simplify tui/ transitions module codes by [@panarch](https://github.com/panarch) in [#37](https://github.com/gluesql/glues/pull/37)
+* Add vim keymap dialogs - Ctrl+h to open by [@panarch](https://github.com/panarch) in [#38](https://github.com/gluesql/glues/pull/38)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.3.2...v0.4.0

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,70 @@
+# 🌊 New Features
+
+## 🚀 Editor Tabs
+
+Introducing editor tabs! You can now navigate multiple open notes seamlessly with the new tab functionality. Use `tl` in Vim normal mode to switch to the next tab, `th` to go to the previous tab, and `tx` to close the current tab. This significantly enhances multitasking and organization within your notes.
+
+
+https://github.com/user-attachments/assets/86b71d10-a5f7-47c6-aa0e-64f6c0e8560d
+
+
+
+## ✨ Vim Mode Enhancements
+
+### Deletion Commands
+Added support for `diw` (delete inside word), `{n}diw` (delete multiple inside words), `d0` (delete to line start), and `d$` (delete to line end).
+- `delete` mode - `d`
+<img width="1011" alt="image" src="https://github.com/user-attachments/assets/984bab55-9d14-45ae-b7a1-8780649af855">
+
+- `delete inside` mode - `di`
+<img width="351" alt="image" src="https://github.com/user-attachments/assets/9b357aa0-8132-4a07-9e4f-12d859ab37a9">
+
+
+
+### Change Commands
+Added support for change mode commands like `c`, `ciw` (change inside word), `{n1}c{n2}` (change multiple parts), and `{n}ciw` (change multiple inside words).
+<img width="730" alt="image" src="https://github.com/user-attachments/assets/6339f738-053b-4369-a526-35e68bd8f9d1">
+
+
+### Toggle Note Browser
+Added a toggle-note-browser feature for normal mode to easily switch between editing and browsing notes using `tb`.
+
+https://github.com/user-attachments/assets/e28834a8-61f9-48e3-b49b-89f62cfa3a83
+
+
+
+## 🛠 Improvements & Fixes
+
+Open Note Key Binding: Changed the open note key binding from o to l for a more intuitive workflow.
+
+Yank Sharing: Yank text is now preserved across notes within a NotebookContext, and yank sharing works correctly across tabs.
+
+Note Management: Fixed the issue where note tree numbering was reset upon certain key inputs (j, k etc.). Also, the rename prompt now shows the current name as the default value for easier editing.
+
+## What's Changed
+* Add AUR instructions to README.md by @orhun in https://github.com/gluesql/glues/pull/39
+* Remove redundant context state management in tui/, by @panarch in https://github.com/gluesql/glues/pull/40
+* Add vim normal delete inside mode - support diw and {n}diw by @panarch in https://github.com/gluesql/glues/pull/41
+* Add {n}d{n2}iw command support - e.g. 3d10iw by @panarch in https://github.com/gluesql/glues/pull/42
+* Add change mode(c) support to vim normal mode by @panarch in https://github.com/gluesql/glues/pull/43
+* Update VimKeymap dialog to calc height automatically by @panarch in https://github.com/gluesql/glues/pull/44
+* Add vim normal change2 mode {n1}c{n2} - 3c20, 2c3, .. by @panarch in https://github.com/gluesql/glues/pull/45
+* Add delete to line start support - d0 by @panarch in https://github.com/gluesql/glues/pull/46
+* Add change inside mode support - ciw, 3ciw 3c2iw, .. by @panarch in https://github.com/gluesql/glues/pull/47
+* Add d$ (delete to line end) support by @panarch in https://github.com/gluesql/glues/pull/48
+* Change open note key binding from 'o' to 'l', by @panarch in https://github.com/gluesql/glues/pull/49
+* Add toggle-note-browser feature to normal mode, by @panarch in https://github.com/gluesql/glues/pull/50
+* Keep yank text across notes in NotebookContext by @panarch in https://github.com/gluesql/glues/pull/51
+* Fix note tree numbering reset on j,k and other key inputs by @panarch in https://github.com/gluesql/glues/pull/52
+* Update rename prompt to show current name as default value by @panarch in https://github.com/gluesql/glues/pull/53
+* Implement editor tabs functionality, by @panarch in https://github.com/gluesql/glues/pull/54
+* Run db::update_note_content only if content changed by @panarch in https://github.com/gluesql/glues/pull/55
+* Hide change mode in top level shortcuts by @panarch in https://github.com/gluesql/glues/pull/56
+* Fix editor to save note on vim modal changes, by @panarch in https://github.com/gluesql/glues/pull/57
+* Fix yank sharing across tabs by @panarch in https://github.com/gluesql/glues/pull/58
+* Update core note::update_content not to return None transition by @panarch in https://github.com/gluesql/glues/pull/59
+
+## New Contributors
+* @orhun made their first contribution in https://github.com/gluesql/glues/pull/39
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.4.0...v0.5.0

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -42,29 +42,29 @@ Yank Sharing: Yank text is now preserved across notes within a NotebookContext, 
 Note Management: Fixed the issue where note tree numbering was reset upon certain key inputs (j, k etc.). Also, the rename prompt now shows the current name as the default value for easier editing.
 
 ## What's Changed
-* Add AUR instructions to README.md by @orhun in https://github.com/gluesql/glues/pull/39
-* Remove redundant context state management in tui/, by @panarch in https://github.com/gluesql/glues/pull/40
-* Add vim normal delete inside mode - support diw and {n}diw by @panarch in https://github.com/gluesql/glues/pull/41
-* Add {n}d{n2}iw command support - e.g. 3d10iw by @panarch in https://github.com/gluesql/glues/pull/42
-* Add change mode(c) support to vim normal mode by @panarch in https://github.com/gluesql/glues/pull/43
-* Update VimKeymap dialog to calc height automatically by @panarch in https://github.com/gluesql/glues/pull/44
-* Add vim normal change2 mode {n1}c{n2} - 3c20, 2c3, .. by @panarch in https://github.com/gluesql/glues/pull/45
-* Add delete to line start support - d0 by @panarch in https://github.com/gluesql/glues/pull/46
-* Add change inside mode support - ciw, 3ciw 3c2iw, .. by @panarch in https://github.com/gluesql/glues/pull/47
-* Add d$ (delete to line end) support by @panarch in https://github.com/gluesql/glues/pull/48
-* Change open note key binding from 'o' to 'l', by @panarch in https://github.com/gluesql/glues/pull/49
-* Add toggle-note-browser feature to normal mode, by @panarch in https://github.com/gluesql/glues/pull/50
-* Keep yank text across notes in NotebookContext by @panarch in https://github.com/gluesql/glues/pull/51
-* Fix note tree numbering reset on j,k and other key inputs by @panarch in https://github.com/gluesql/glues/pull/52
-* Update rename prompt to show current name as default value by @panarch in https://github.com/gluesql/glues/pull/53
-* Implement editor tabs functionality, by @panarch in https://github.com/gluesql/glues/pull/54
-* Run db::update_note_content only if content changed by @panarch in https://github.com/gluesql/glues/pull/55
-* Hide change mode in top level shortcuts by @panarch in https://github.com/gluesql/glues/pull/56
-* Fix editor to save note on vim modal changes, by @panarch in https://github.com/gluesql/glues/pull/57
-* Fix yank sharing across tabs by @panarch in https://github.com/gluesql/glues/pull/58
-* Update core note::update_content not to return None transition by @panarch in https://github.com/gluesql/glues/pull/59
+* Add AUR instructions to README.md by [@orhun](https://github.com/orhun) in [#39](https://github.com/gluesql/glues/pull/39)
+* Remove redundant context state management in tui/, by [@panarch](https://github.com/panarch) in [#40](https://github.com/gluesql/glues/pull/40)
+* Add vim normal delete inside mode - support diw and {n}diw by [@panarch](https://github.com/panarch) in [#41](https://github.com/gluesql/glues/pull/41)
+* Add {n}d{n2}iw command support - e.g. 3d10iw by [@panarch](https://github.com/panarch) in [#42](https://github.com/gluesql/glues/pull/42)
+* Add change mode(c) support to vim normal mode by [@panarch](https://github.com/panarch) in [#43](https://github.com/gluesql/glues/pull/43)
+* Update VimKeymap dialog to calc height automatically by [@panarch](https://github.com/panarch) in [#44](https://github.com/gluesql/glues/pull/44)
+* Add vim normal change2 mode {n1}c{n2} - 3c20, 2c3, .. by [@panarch](https://github.com/panarch) in [#45](https://github.com/gluesql/glues/pull/45)
+* Add delete to line start support - d0 by [@panarch](https://github.com/panarch) in [#46](https://github.com/gluesql/glues/pull/46)
+* Add change inside mode support - ciw, 3ciw 3c2iw, .. by [@panarch](https://github.com/panarch) in [#47](https://github.com/gluesql/glues/pull/47)
+* Add d$ (delete to line end) support by [@panarch](https://github.com/panarch) in [#48](https://github.com/gluesql/glues/pull/48)
+* Change open note key binding from 'o' to 'l', by [@panarch](https://github.com/panarch) in [#49](https://github.com/gluesql/glues/pull/49)
+* Add toggle-note-browser feature to normal mode, by [@panarch](https://github.com/panarch) in [#50](https://github.com/gluesql/glues/pull/50)
+* Keep yank text across notes in NotebookContext by [@panarch](https://github.com/panarch) in [#51](https://github.com/gluesql/glues/pull/51)
+* Fix note tree numbering reset on j,k and other key inputs by [@panarch](https://github.com/panarch) in [#52](https://github.com/gluesql/glues/pull/52)
+* Update rename prompt to show current name as default value by [@panarch](https://github.com/panarch) in [#53](https://github.com/gluesql/glues/pull/53)
+* Implement editor tabs functionality, by [@panarch](https://github.com/panarch) in [#54](https://github.com/gluesql/glues/pull/54)
+* Run db::update_note_content only if content changed by [@panarch](https://github.com/panarch) in [#55](https://github.com/gluesql/glues/pull/55)
+* Hide change mode in top level shortcuts by [@panarch](https://github.com/panarch) in [#56](https://github.com/gluesql/glues/pull/56)
+* Fix editor to save note on vim modal changes, by [@panarch](https://github.com/panarch) in [#57](https://github.com/gluesql/glues/pull/57)
+* Fix yank sharing across tabs by [@panarch](https://github.com/panarch) in [#58](https://github.com/gluesql/glues/pull/58)
+* Update core note::update_content not to return None transition by [@panarch](https://github.com/panarch) in [#59](https://github.com/gluesql/glues/pull/59)
 
 ## New Contributors
-* @orhun made their first contribution in https://github.com/gluesql/glues/pull/39
+* [@orhun](https://github.com/orhun) made their first contribution in [#39](https://github.com/gluesql/glues/pull/39)
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.4.0...v0.5.0

--- a/docs/releases/v0.5.1.md
+++ b/docs/releases/v0.5.1.md
@@ -1,0 +1,15 @@
+## What's Changed
+* Add keymap dialog to editing normal delete & delete numbering modes by @panarch in https://github.com/gluesql/glues/pull/61
+* Apply async to tui/ transition handler methods, by @panarch in https://github.com/gluesql/glues/pull/63
+* Remove unnecessary event handling codes in NotebookContext by @panarch in https://github.com/gluesql/glues/pull/64
+* Add support for arrow keys in various modes by @bangseongbeom in https://github.com/gluesql/glues/pull/66
+* Add Enter key binding to toggle directories in note browser by @doxxx93 in https://github.com/gluesql/glues/pull/67
+* Fix [e] command description in vim keymap help by @doxxx93 in https://github.com/gluesql/glues/pull/70
+* Feat: Add support for deleting a word in normal mode with `de`, `db` by @nickhealthy in https://github.com/gluesql/glues/pull/68
+
+## New Contributors
+* @bangseongbeom made their first contribution in https://github.com/gluesql/glues/pull/66
+* @doxxx93 made their first contribution in https://github.com/gluesql/glues/pull/67
+* @nickhealthy made their first contribution in https://github.com/gluesql/glues/pull/68
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.0...v0.5.1

--- a/docs/releases/v0.5.1.md
+++ b/docs/releases/v0.5.1.md
@@ -1,15 +1,15 @@
 ## What's Changed
-* Add keymap dialog to editing normal delete & delete numbering modes by @panarch in https://github.com/gluesql/glues/pull/61
-* Apply async to tui/ transition handler methods, by @panarch in https://github.com/gluesql/glues/pull/63
-* Remove unnecessary event handling codes in NotebookContext by @panarch in https://github.com/gluesql/glues/pull/64
-* Add support for arrow keys in various modes by @bangseongbeom in https://github.com/gluesql/glues/pull/66
-* Add Enter key binding to toggle directories in note browser by @doxxx93 in https://github.com/gluesql/glues/pull/67
-* Fix [e] command description in vim keymap help by @doxxx93 in https://github.com/gluesql/glues/pull/70
-* Feat: Add support for deleting a word in normal mode with `de`, `db` by @nickhealthy in https://github.com/gluesql/glues/pull/68
+* Add keymap dialog to editing normal delete & delete numbering modes by [@panarch](https://github.com/panarch) in [#61](https://github.com/gluesql/glues/pull/61)
+* Apply async to tui/ transition handler methods, by [@panarch](https://github.com/panarch) in [#63](https://github.com/gluesql/glues/pull/63)
+* Remove unnecessary event handling codes in NotebookContext by [@panarch](https://github.com/panarch) in [#64](https://github.com/gluesql/glues/pull/64)
+* Add support for arrow keys in various modes by [@bangseongbeom](https://github.com/bangseongbeom) in [#66](https://github.com/gluesql/glues/pull/66)
+* Add Enter key binding to toggle directories in note browser by [@doxxx93](https://github.com/doxxx93) in [#67](https://github.com/gluesql/glues/pull/67)
+* Fix [e] command description in vim keymap help by [@doxxx93](https://github.com/doxxx93) in [#70](https://github.com/gluesql/glues/pull/70)
+* Feat: Add support for deleting a word in normal mode with `de`, `db` by [@nickhealthy](https://github.com/nickhealthy) in [#68](https://github.com/gluesql/glues/pull/68)
 
 ## New Contributors
-* @bangseongbeom made their first contribution in https://github.com/gluesql/glues/pull/66
-* @doxxx93 made their first contribution in https://github.com/gluesql/glues/pull/67
-* @nickhealthy made their first contribution in https://github.com/gluesql/glues/pull/68
+* [@bangseongbeom](https://github.com/bangseongbeom) made their first contribution in [#66](https://github.com/gluesql/glues/pull/66)
+* [@doxxx93](https://github.com/doxxx93) made their first contribution in [#67](https://github.com/gluesql/glues/pull/67)
+* [@nickhealthy](https://github.com/nickhealthy) made their first contribution in [#68](https://github.com/gluesql/glues/pull/68)
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.0...v0.5.1

--- a/docs/releases/v0.5.2.md
+++ b/docs/releases/v0.5.2.md
@@ -1,0 +1,13 @@
+## What's Changed
+* Update editor to instant save on tab close by @panarch in https://github.com/gluesql/glues/pull/72
+* Fix not to crash on last tab closing by @panarch in https://github.com/gluesql/glues/pull/73
+* Add Tab key support for toggling focus between note tree and editor by @panarch in https://github.com/gluesql/glues/pull/74
+* Fix crash when switching focus to editor with Tab while root is closed by @panarch in https://github.com/gluesql/glues/pull/75
+* Remove legacy traverse module in core by @panarch in https://github.com/gluesql/glues/pull/76
+* Remove wildcard use in handle_notebook_transition match by @panarch in https://github.com/gluesql/glues/pull/77
+* Add tilde(~) switch case support to vim normal & visual modes by @panarch in https://github.com/gluesql/glues/pull/78
+* Add to_{upper|lower}case support to visual mode (u & U) by @panarch in https://github.com/gluesql/glues/pull/79
+* Add dj & dl support - {n1}d{n2}{h | l} by @panarch in https://github.com/gluesql/glues/pull/80
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.1...v0.5.2

--- a/docs/releases/v0.5.2.md
+++ b/docs/releases/v0.5.2.md
@@ -1,13 +1,13 @@
 ## What's Changed
-* Update editor to instant save on tab close by @panarch in https://github.com/gluesql/glues/pull/72
-* Fix not to crash on last tab closing by @panarch in https://github.com/gluesql/glues/pull/73
-* Add Tab key support for toggling focus between note tree and editor by @panarch in https://github.com/gluesql/glues/pull/74
-* Fix crash when switching focus to editor with Tab while root is closed by @panarch in https://github.com/gluesql/glues/pull/75
-* Remove legacy traverse module in core by @panarch in https://github.com/gluesql/glues/pull/76
-* Remove wildcard use in handle_notebook_transition match by @panarch in https://github.com/gluesql/glues/pull/77
-* Add tilde(~) switch case support to vim normal & visual modes by @panarch in https://github.com/gluesql/glues/pull/78
-* Add to_{upper|lower}case support to visual mode (u & U) by @panarch in https://github.com/gluesql/glues/pull/79
-* Add dj & dl support - {n1}d{n2}{h | l} by @panarch in https://github.com/gluesql/glues/pull/80
+* Update editor to instant save on tab close by [@panarch](https://github.com/panarch) in [#72](https://github.com/gluesql/glues/pull/72)
+* Fix not to crash on last tab closing by [@panarch](https://github.com/panarch) in [#73](https://github.com/gluesql/glues/pull/73)
+* Add Tab key support for toggling focus between note tree and editor by [@panarch](https://github.com/panarch) in [#74](https://github.com/gluesql/glues/pull/74)
+* Fix crash when switching focus to editor with Tab while root is closed by [@panarch](https://github.com/panarch) in [#75](https://github.com/gluesql/glues/pull/75)
+* Remove legacy traverse module in core by [@panarch](https://github.com/panarch) in [#76](https://github.com/gluesql/glues/pull/76)
+* Remove wildcard use in handle_notebook_transition match by [@panarch](https://github.com/panarch) in [#77](https://github.com/gluesql/glues/pull/77)
+* Add tilde(~) switch case support to vim normal & visual modes by [@panarch](https://github.com/panarch) in [#78](https://github.com/gluesql/glues/pull/78)
+* Add to_{upper|lower}case support to visual mode (u & U) by [@panarch](https://github.com/panarch) in [#79](https://github.com/gluesql/glues/pull/79)
+* Add dj & dl support - {n1}d{n2}{h | l} by [@panarch](https://github.com/panarch) in [#80](https://github.com/gluesql/glues/pull/80)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.1...v0.5.2

--- a/docs/releases/v0.5.3.md
+++ b/docs/releases/v0.5.3.md
@@ -1,9 +1,9 @@
 ## What's Changed
-* Add {n}d{n2}$ support - 3d2$, d4$, .. by @panarch in https://github.com/gluesql/glues/pull/83
-* Add de & db support to delete2 mode - 3d2e, d4b, .. by @panarch in https://github.com/gluesql/glues/pull/84
-* Update gluesql version to v0.16.3 by @panarch in https://github.com/gluesql/glues/pull/85
-* Bump gluesql-mongo-storage version to 0.16.3 by @panarch in https://github.com/gluesql/glues/pull/86
-* Add z scroll support - zz, zt and zb by @panarch in https://github.com/gluesql/glues/pull/87
+* Add {n}d{n2}$ support - 3d2$, d4$, .. by [@panarch](https://github.com/panarch) in [#83](https://github.com/gluesql/glues/pull/83)
+* Add de & db support to delete2 mode - 3d2e, d4b, .. by [@panarch](https://github.com/panarch) in [#84](https://github.com/gluesql/glues/pull/84)
+* Update gluesql version to v0.16.3 by [@panarch](https://github.com/panarch) in [#85](https://github.com/gluesql/glues/pull/85)
+* Bump gluesql-mongo-storage version to 0.16.3 by [@panarch](https://github.com/panarch) in [#86](https://github.com/gluesql/glues/pull/86)
+* Add z scroll support - zz, zt and zb by [@panarch](https://github.com/panarch) in [#87](https://github.com/gluesql/glues/pull/87)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.2...v0.5.3

--- a/docs/releases/v0.5.3.md
+++ b/docs/releases/v0.5.3.md
@@ -1,0 +1,9 @@
+## What's Changed
+* Add {n}d{n2}$ support - 3d2$, d4$, .. by @panarch in https://github.com/gluesql/glues/pull/83
+* Add de & db support to delete2 mode - 3d2e, d4b, .. by @panarch in https://github.com/gluesql/glues/pull/84
+* Update gluesql version to v0.16.3 by @panarch in https://github.com/gluesql/glues/pull/85
+* Bump gluesql-mongo-storage version to 0.16.3 by @panarch in https://github.com/gluesql/glues/pull/86
+* Add z scroll support - zz, zt and zb by @panarch in https://github.com/gluesql/glues/pull/87
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.2...v0.5.3

--- a/docs/releases/v0.5.4.md
+++ b/docs/releases/v0.5.4.md
@@ -1,0 +1,8 @@
+## What's Changed
+* Update Vim keymap dialog - add z mode description to normal keymap by @panarch in https://github.com/gluesql/glues/pull/89
+* Run auto save before Ctrl+C app close triggered by @panarch in https://github.com/gluesql/glues/pull/90
+* Implement move-tab-{prev|next} support with tH | tL shortcuts by @panarch in https://github.com/gluesql/glues/pull/91
+* Trim trailing whitespace in content comparison to avoid unnecessary d… by @panarch in https://github.com/gluesql/glues/pull/92
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.3...v0.5.4

--- a/docs/releases/v0.5.4.md
+++ b/docs/releases/v0.5.4.md
@@ -1,8 +1,8 @@
 ## What's Changed
-* Update Vim keymap dialog - add z mode description to normal keymap by @panarch in https://github.com/gluesql/glues/pull/89
-* Run auto save before Ctrl+C app close triggered by @panarch in https://github.com/gluesql/glues/pull/90
-* Implement move-tab-{prev|next} support with tH | tL shortcuts by @panarch in https://github.com/gluesql/glues/pull/91
-* Trim trailing whitespace in content comparison to avoid unnecessary d… by @panarch in https://github.com/gluesql/glues/pull/92
+* Update Vim keymap dialog - add z mode description to normal keymap by [@panarch](https://github.com/panarch) in [#89](https://github.com/gluesql/glues/pull/89)
+* Run auto save before Ctrl+C app close triggered by [@panarch](https://github.com/panarch) in [#90](https://github.com/gluesql/glues/pull/90)
+* Implement move-tab-{prev|next} support with tH | tL shortcuts by [@panarch](https://github.com/panarch) in [#91](https://github.com/gluesql/glues/pull/91)
+* Trim trailing whitespace in content comparison to avoid unnecessary d… by [@panarch](https://github.com/panarch) in [#92](https://github.com/gluesql/glues/pull/92)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.3...v0.5.4

--- a/docs/releases/v0.5.5.md
+++ b/docs/releases/v0.5.5.md
@@ -1,5 +1,5 @@
 ## What's Changed
-* Implement note & directory move functionality by @panarch in https://github.com/gluesql/glues/pull/94
+* Implement note & directory move functionality by [@panarch](https://github.com/panarch) in [#94](https://github.com/gluesql/glues/pull/94)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.4...v0.5.5

--- a/docs/releases/v0.5.5.md
+++ b/docs/releases/v0.5.5.md
@@ -1,0 +1,5 @@
+## What's Changed
+* Implement note & directory move functionality by @panarch in https://github.com/gluesql/glues/pull/94
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.4...v0.5.5

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,64 @@
+Hello everyone. I've been using Glues as my main note-taking app, and I'm pleased to share this update. Here's a brief look at what's new. Expect more improvements soon!
+
+## Main Highlights
+
+### Design Renewal
+- **256-Color Support**  
+  Switched from just 16 ANSI colors to 256 colors. Everything now looks way more vibrant and consistent, no matter which terminal you’re using.  
+<img width="1496" alt="스크린샷 2025-02-11 오후 8 29 40" src="https://github.com/user-attachments/assets/2285586a-09dd-46ef-bac5-c83cd36046fc" />
+
+- **Better Note Tree Browser**  
+  - Added Nerd Font icons for directories and notes, so it’s easier to see what’s what at a glance.  
+  - Directories get a neat yellow icon, and notes have dimmer icons for contrast.  
+<img width="595" alt="스크린샷 2025-02-11 오후 8 30 58" src="https://github.com/user-attachments/assets/74befc8c-c5c3-4c4a-b11e-0769b75f7920" />
+
+- **New Bottom Status Area**  
+  - Shows Vim mode (Normal/Insert/Visual) on the bottom-left corner.  
+  - Displays a breadcrumb to let you know exactly where you are.  
+  - Hides the Vim mode label when no tabs are open—clean and simple.  
+<img width="854" alt="스크린샷 2025-02-11 오후 8 32 06" src="https://github.com/user-attachments/assets/e635603f-d471-4897-8145-c44c41bb7eb1" />
+
+### Keymap Side Panel
+- Press `?` to toggle a handy panel on the right with **all** the key mappings.  
+- No more cramming everything into a single top row. Now you can open/close the panel anytime you want.  
+<img width="625" alt="스크린샷 2025-02-11 오후 8 31 21" src="https://github.com/user-attachments/assets/a4a5ec22-bc9c-4877-b052-17adb7b8f67f" />
+
+## Additional Improvements
+- **Tab Closing Tweaks**: You can now close all tabs on the right or all on the left.  
+- **Cleaner Tab Rendering**: Removed the square brackets around editor tabs.  
+- **“Saving…” Label Update**: Redesigned for better visibility.  
+- **OS Clipboard Integration**: Yanked text goes straight to your system clipboard.  
+- **Vim ‘a’ Command Fix**: Properly inserts text at the end of a line.  
+- **Rust Update**: Bumped to version 1.84.  
+- Plus various refactoring and logging upgrades under the hood.
+
+Hope you find these changes helpful! I’m loving it so far and will keep improving Glues for everyone. Enjoy!
+
+
+
+## What's Changed
+* Fix note rename to apply changes to open tabs in TUI by @panarch in https://github.com/gluesql/glues/pull/96
+* Implement breadcrumb support in tui editor by @panarch in https://github.com/gluesql/glues/pull/97
+* Update tui/ editor to show vim mode at bottom left corner by @panarch in https://github.com/gluesql/glues/pull/98
+* Remove surrounding borders in note tree & editor and leave only divid… by @panarch in https://github.com/gluesql/glues/pull/99
+* Remove square bracket uses in editor tab rendering by @panarch in https://github.com/gluesql/glues/pull/100
+* Apply Nerd Font icons to NoteTree by @panarch in https://github.com/gluesql/glues/pull/101
+* Apply NerdFont to editor - tabs & bottom right status message by @panarch in https://github.com/gluesql/glues/pull/102
+* Add tab close mode with closing all right tabs by @panarch in https://github.com/gluesql/glues/pull/103
+* Add closing all left tabs (normal mode - tXh) by @panarch in https://github.com/gluesql/glues/pull/104
+* Change NoteTree icon colors - directory to yellow & note to dimmed by @panarch in https://github.com/gluesql/glues/pull/105
+* Replace colors - named ANSI colors to other indexed colors by @panarch in https://github.com/gluesql/glues/pull/106
+* Move tab management including breadcrumb from tui/ to core/ by @panarch in https://github.com/gluesql/glues/pull/107
+* Add logger to core module by @panarch in https://github.com/gluesql/glues/pull/108
+* Make editor breadcrumb look better by @panarch in https://github.com/gluesql/glues/pull/109
+* Update rust-toolchain rust version to 1.84 by @panarch in https://github.com/gluesql/glues/pull/110
+* Update editor yank to set OS clipboard by @panarch in https://github.com/gluesql/glues/pull/111
+* Update editor 'Saving...' bottom-right label design by @panarch in https://github.com/gluesql/glues/pull/112
+* Hide Vim mode label in editor if no tabs open by @panarch in https://github.com/gluesql/glues/pull/113
+* Fix 'a' behavior in Vim normal mode to stop at line end by @panarch in https://github.com/gluesql/glues/pull/114
+* Split tui/transitions.rs into sub modules by @panarch in https://github.com/gluesql/glues/pull/115
+* Implement Keymap side panel UI/UX by @panarch in https://github.com/gluesql/glues/pull/116
+* Release v0.6.0 by @panarch in https://github.com/gluesql/glues/pull/117
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.5...v0.6.0

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -37,28 +37,28 @@ Hope you find these changes helpful! I’m loving it so far and will keep improv
 
 
 ## What's Changed
-* Fix note rename to apply changes to open tabs in TUI by @panarch in https://github.com/gluesql/glues/pull/96
-* Implement breadcrumb support in tui editor by @panarch in https://github.com/gluesql/glues/pull/97
-* Update tui/ editor to show vim mode at bottom left corner by @panarch in https://github.com/gluesql/glues/pull/98
-* Remove surrounding borders in note tree & editor and leave only divid… by @panarch in https://github.com/gluesql/glues/pull/99
-* Remove square bracket uses in editor tab rendering by @panarch in https://github.com/gluesql/glues/pull/100
-* Apply Nerd Font icons to NoteTree by @panarch in https://github.com/gluesql/glues/pull/101
-* Apply NerdFont to editor - tabs & bottom right status message by @panarch in https://github.com/gluesql/glues/pull/102
-* Add tab close mode with closing all right tabs by @panarch in https://github.com/gluesql/glues/pull/103
-* Add closing all left tabs (normal mode - tXh) by @panarch in https://github.com/gluesql/glues/pull/104
-* Change NoteTree icon colors - directory to yellow & note to dimmed by @panarch in https://github.com/gluesql/glues/pull/105
-* Replace colors - named ANSI colors to other indexed colors by @panarch in https://github.com/gluesql/glues/pull/106
-* Move tab management including breadcrumb from tui/ to core/ by @panarch in https://github.com/gluesql/glues/pull/107
-* Add logger to core module by @panarch in https://github.com/gluesql/glues/pull/108
-* Make editor breadcrumb look better by @panarch in https://github.com/gluesql/glues/pull/109
-* Update rust-toolchain rust version to 1.84 by @panarch in https://github.com/gluesql/glues/pull/110
-* Update editor yank to set OS clipboard by @panarch in https://github.com/gluesql/glues/pull/111
-* Update editor 'Saving...' bottom-right label design by @panarch in https://github.com/gluesql/glues/pull/112
-* Hide Vim mode label in editor if no tabs open by @panarch in https://github.com/gluesql/glues/pull/113
-* Fix 'a' behavior in Vim normal mode to stop at line end by @panarch in https://github.com/gluesql/glues/pull/114
-* Split tui/transitions.rs into sub modules by @panarch in https://github.com/gluesql/glues/pull/115
-* Implement Keymap side panel UI/UX by @panarch in https://github.com/gluesql/glues/pull/116
-* Release v0.6.0 by @panarch in https://github.com/gluesql/glues/pull/117
+* Fix note rename to apply changes to open tabs in TUI by [@panarch](https://github.com/panarch) in [#96](https://github.com/gluesql/glues/pull/96)
+* Implement breadcrumb support in tui editor by [@panarch](https://github.com/panarch) in [#97](https://github.com/gluesql/glues/pull/97)
+* Update tui/ editor to show vim mode at bottom left corner by [@panarch](https://github.com/panarch) in [#98](https://github.com/gluesql/glues/pull/98)
+* Remove surrounding borders in note tree & editor and leave only divid… by [@panarch](https://github.com/panarch) in [#99](https://github.com/gluesql/glues/pull/99)
+* Remove square bracket uses in editor tab rendering by [@panarch](https://github.com/panarch) in [#100](https://github.com/gluesql/glues/pull/100)
+* Apply Nerd Font icons to NoteTree by [@panarch](https://github.com/panarch) in [#101](https://github.com/gluesql/glues/pull/101)
+* Apply NerdFont to editor - tabs & bottom right status message by [@panarch](https://github.com/panarch) in [#102](https://github.com/gluesql/glues/pull/102)
+* Add tab close mode with closing all right tabs by [@panarch](https://github.com/panarch) in [#103](https://github.com/gluesql/glues/pull/103)
+* Add closing all left tabs (normal mode - tXh) by [@panarch](https://github.com/panarch) in [#104](https://github.com/gluesql/glues/pull/104)
+* Change NoteTree icon colors - directory to yellow & note to dimmed by [@panarch](https://github.com/panarch) in [#105](https://github.com/gluesql/glues/pull/105)
+* Replace colors - named ANSI colors to other indexed colors by [@panarch](https://github.com/panarch) in [#106](https://github.com/gluesql/glues/pull/106)
+* Move tab management including breadcrumb from tui/ to core/ by [@panarch](https://github.com/panarch) in [#107](https://github.com/gluesql/glues/pull/107)
+* Add logger to core module by [@panarch](https://github.com/panarch) in [#108](https://github.com/gluesql/glues/pull/108)
+* Make editor breadcrumb look better by [@panarch](https://github.com/panarch) in [#109](https://github.com/gluesql/glues/pull/109)
+* Update rust-toolchain rust version to 1.84 by [@panarch](https://github.com/panarch) in [#110](https://github.com/gluesql/glues/pull/110)
+* Update editor yank to set OS clipboard by [@panarch](https://github.com/panarch) in [#111](https://github.com/gluesql/glues/pull/111)
+* Update editor 'Saving...' bottom-right label design by [@panarch](https://github.com/panarch) in [#112](https://github.com/gluesql/glues/pull/112)
+* Hide Vim mode label in editor if no tabs open by [@panarch](https://github.com/panarch) in [#113](https://github.com/gluesql/glues/pull/113)
+* Fix 'a' behavior in Vim normal mode to stop at line end by [@panarch](https://github.com/panarch) in [#114](https://github.com/gluesql/glues/pull/114)
+* Split tui/transitions.rs into sub modules by [@panarch](https://github.com/panarch) in [#115](https://github.com/gluesql/glues/pull/115)
+* Implement Keymap side panel UI/UX by [@panarch](https://github.com/panarch) in [#116](https://github.com/gluesql/glues/pull/116)
+* Release v0.6.0 by [@panarch](https://github.com/panarch) in [#117](https://github.com/gluesql/glues/pull/117)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.5.5...v0.6.0

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,12 +1,12 @@
 ## What's Changed
-* Change note_tree right boder style and color by @panarch in https://github.com/gluesql/glues/pull/118
-* Add NoteTree sub state to core/ Notebook::InnerState by @panarch in https://github.com/gluesql/glues/pull/120
-* Add NoteTreeTransition sub transition enum to NotebookTransition by @panarch in https://github.com/gluesql/glues/pull/121
-* Split tui/ transitions into sub modules by @panarch in https://github.com/gluesql/glues/pull/122
-* Rust 2024 edition by @panarch in https://github.com/gluesql/glues/pull/123
-* Add select-last (G) key support to NoteTree by @panarch in https://github.com/gluesql/glues/pull/124
-* Add expand(<) and shrink(>) width support to NoteTree by @panarch in https://github.com/gluesql/glues/pull/125
-* Add select-first (gg) key support to NoteTree by @panarch in https://github.com/gluesql/glues/pull/126
+* Change note_tree right boder style and color by [@panarch](https://github.com/panarch) in [#118](https://github.com/gluesql/glues/pull/118)
+* Add NoteTree sub state to core/ Notebook::InnerState by [@panarch](https://github.com/panarch) in [#120](https://github.com/gluesql/glues/pull/120)
+* Add NoteTreeTransition sub transition enum to NotebookTransition by [@panarch](https://github.com/panarch) in [#121](https://github.com/gluesql/glues/pull/121)
+* Split tui/ transitions into sub modules by [@panarch](https://github.com/panarch) in [#122](https://github.com/gluesql/glues/pull/122)
+* Rust 2024 edition by [@panarch](https://github.com/panarch) in [#123](https://github.com/gluesql/glues/pull/123)
+* Add select-last (G) key support to NoteTree by [@panarch](https://github.com/panarch) in [#124](https://github.com/gluesql/glues/pull/124)
+* Add expand(<) and shrink(>) width support to NoteTree by [@panarch](https://github.com/panarch) in [#125](https://github.com/gluesql/glues/pull/125)
+* Add select-first (gg) key support to NoteTree by [@panarch](https://github.com/panarch) in [#126](https://github.com/gluesql/glues/pull/126)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.6.0...v0.6.1

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,0 +1,12 @@
+## What's Changed
+* Change note_tree right boder style and color by @panarch in https://github.com/gluesql/glues/pull/118
+* Add NoteTree sub state to core/ Notebook::InnerState by @panarch in https://github.com/gluesql/glues/pull/120
+* Add NoteTreeTransition sub transition enum to NotebookTransition by @panarch in https://github.com/gluesql/glues/pull/121
+* Split tui/ transitions into sub modules by @panarch in https://github.com/gluesql/glues/pull/122
+* Rust 2024 edition by @panarch in https://github.com/gluesql/glues/pull/123
+* Add select-last (G) key support to NoteTree by @panarch in https://github.com/gluesql/glues/pull/124
+* Add expand(<) and shrink(>) width support to NoteTree by @panarch in https://github.com/gluesql/glues/pull/125
+* Add select-first (gg) key support to NoteTree by @panarch in https://github.com/gluesql/glues/pull/126
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.6.0...v0.6.1

--- a/docs/releases/v0.6.2.md
+++ b/docs/releases/v0.6.2.md
@@ -1,6 +1,6 @@
 ## What's Changed
-* Add NoteTree select next(J) & prev(K) directory by @panarch in https://github.com/gluesql/glues/pull/128
-* Fix keymap dialog not updating live with current TUI state by @panarch in https://github.com/gluesql/glues/pull/129
+* Add NoteTree select next(J) & prev(K) directory by [@panarch](https://github.com/panarch) in [#128](https://github.com/gluesql/glues/pull/128)
+* Fix keymap dialog not updating live with current TUI state by [@panarch](https://github.com/panarch) in [#129](https://github.com/gluesql/glues/pull/129)
 
 
 **Full Changelog**: https://github.com/gluesql/glues/compare/v0.6.1...v0.6.2

--- a/docs/releases/v0.6.2.md
+++ b/docs/releases/v0.6.2.md
@@ -1,0 +1,6 @@
+## What's Changed
+* Add NoteTree select next(J) & prev(K) directory by @panarch in https://github.com/gluesql/glues/pull/128
+* Fix keymap dialog not updating live with current TUI state by @panarch in https://github.com/gluesql/glues/pull/129
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.6.1...v0.6.2

--- a/docs/releases/v0.6.3.md
+++ b/docs/releases/v0.6.3.md
@@ -1,0 +1,12 @@
+## What's Changed
+* Leave gateway mode on inedible key events by @panarch in https://github.com/gluesql/glues/pull/132
+* Clarify add failure messages by @panarch in https://github.com/gluesql/glues/pull/133
+* Add missing delete mode shortcuts by @panarch in https://github.com/gluesql/glues/pull/134
+* Support row deletion using j & k shortcuts by @panarch in https://github.com/gluesql/glues/pull/135
+* Rename shortcuts method to keymap by @panarch in https://github.com/gluesql/glues/pull/136
+* Fix shortcut keys for Git and MongoDB selection in entry menu by @panarch in https://github.com/gluesql/glues/pull/137
+* Improve grammar in the path creation prompt by @panarch in https://github.com/gluesql/glues/pull/138
+
+
+
+**Full Changelog**: https://github.com/gluesql/glues/compare/v0.6.2...v0.6.3

--- a/docs/releases/v0.6.3.md
+++ b/docs/releases/v0.6.3.md
@@ -1,11 +1,11 @@
 ## What's Changed
-* Leave gateway mode on inedible key events by @panarch in https://github.com/gluesql/glues/pull/132
-* Clarify add failure messages by @panarch in https://github.com/gluesql/glues/pull/133
-* Add missing delete mode shortcuts by @panarch in https://github.com/gluesql/glues/pull/134
-* Support row deletion using j & k shortcuts by @panarch in https://github.com/gluesql/glues/pull/135
-* Rename shortcuts method to keymap by @panarch in https://github.com/gluesql/glues/pull/136
-* Fix shortcut keys for Git and MongoDB selection in entry menu by @panarch in https://github.com/gluesql/glues/pull/137
-* Improve grammar in the path creation prompt by @panarch in https://github.com/gluesql/glues/pull/138
+* Leave gateway mode on inedible key events by [@panarch](https://github.com/panarch) in [#132](https://github.com/gluesql/glues/pull/132)
+* Clarify add failure messages by [@panarch](https://github.com/panarch) in [#133](https://github.com/gluesql/glues/pull/133)
+* Add missing delete mode shortcuts by [@panarch](https://github.com/panarch) in [#134](https://github.com/gluesql/glues/pull/134)
+* Support row deletion using j & k shortcuts by [@panarch](https://github.com/panarch) in [#135](https://github.com/gluesql/glues/pull/135)
+* Rename shortcuts method to keymap by [@panarch](https://github.com/panarch) in [#136](https://github.com/gluesql/glues/pull/136)
+* Fix shortcut keys for Git and MongoDB selection in entry menu by [@panarch](https://github.com/panarch) in [#137](https://github.com/gluesql/glues/pull/137)
+* Improve grammar in the path creation prompt by [@panarch](https://github.com/panarch) in [#138](https://github.com/gluesql/glues/pull/138)
 
 
 

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,64 @@
+# Glues v0.7.0 – Release Notes
+
+## ✨ Highlights
+
+### Unified Theme Engine  
+Glues now drives every UI color through a central **Theme** system.
+
+- **Palette switcher** – choose a theme at launch with  
+  ```bash
+  glues --theme <dark|light|pastel|sunrise|midnight|forest>
+  ```
+- **256-color vs. TrueColor**  
+  * **Dark** / **Light** → tuned for 256-color (legacy) terminals.  
+  * **Pastel**, **Sunrise**, **Midnight**, **Forest** → full RGB palettes; best on true-color terminals.  
+- Internals were refactored so adding or tweaking palettes is now painless.  
+
+<img width="1300" alt="스크린샷 2025-06-14 오후 7 43 44" src="https://github.com/user-attachments/assets/104d3561-6578-45d5-90e9-1ff95ec4b7b3" />
+<img width="1300" alt="스크린샷 2025-06-14 오후 7 43 48" src="https://github.com/user-attachments/assets/a09d3c62-9aa9-4d74-ab72-8b9c493d71d6" />
+
+
+
+  **PRs:**  
+  - [#140](https://github.com/gluesql/glues/pull/140) – move color constants into a theme module  
+  - [#144](https://github.com/gluesql/glues/pull/144) – `--theme` CLI option (Dark/Light)  
+  - [#145](https://github.com/gluesql/glues/pull/145) – add **Pastel** + module re-org  
+  - [#147](https://github.com/gluesql/glues/pull/147) – add **Sunrise**, **Midnight**, **Forest**
+
+### Smarter Keymap Dialog  
+Key bindings appear under logical group headings, making the help popup far easier to scan.  
+  **PR:** [#149](https://github.com/gluesql/glues/pull/149)
+
+---
+
+## 🛠 Other Improvements
+
+- **Proxy client/server layer** *(experimental)* – run the TUI locally while delegating note ops to a remote Glues core.  
+  **PR:** [#150](https://github.com/gluesql/glues/pull/150)
+
+- **Extensible storage backend** – `Db` struct replaced by a `CoreBackend` trait.  
+  **PR:** [#148](https://github.com/gluesql/glues/pull/148)
+
+- **Keymap rendering cleanup** – unified return types and tighter TUI layout.  
+  **PRs:** [#141](https://github.com/gluesql/glues/pull/141), [#154](https://github.com/gluesql/glues/pull/154)
+
+- **Visual & normal-mode refactor** – huge state files split into focused modules.  
+  **PRs:** [#151](https://github.com/gluesql/glues/pull/151), [#153](https://github.com/gluesql/glues/pull/153)
+
+- **Richer error variants** – replaced `Error::Wip`, improved `Error::Todo` messages.  
+  **PRs:** [#159](https://github.com/gluesql/glues/pull/159), [#160](https://github.com/gluesql/glues/pull/160)
+
+- **CI hygiene** – every Codex run now enforces `cargo clippy` & `cargo fmt`.  
+  **PR:** [#162](https://github.com/gluesql/glues/pull/162)
+
+---
+
+## 🐞 Bug Fixes
+
+- Fixed tab cycling that sometimes skipped tabs.  
+  **PR:** [#143](https://github.com/gluesql/glues/pull/143)
+
+---
+
+### 🔗 Full Changelog  
+<https://github.com/gluesql/glues/compare/v0.6.3...v0.7.0>


### PR DESCRIPTION
## Summary
- import existing GitHub release notes into docs/releases for each tagged release with content
- normalize line endings while keeping upstream formatting intact; skip releases without notes

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo fmt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added release notes for v0.3.1–v0.7.0.
  - Highlights: TUI migration to Ratatui; LTO for release builds; MongoDB storage backend; Vim-inspired editing (normal/visual modes, delete/change/yank, case toggles, z-scroll, dj/dl, de/db, {n}d{n2}$); editor tabs, tab management, instant save on close; move notes/directories; enhanced NoteTree navigation/resizing; UI refresh (256-color, status area, keymap panel, Nerd Font icons); unified theme engine; clipboard and various usability fixes. Links to full changelogs included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->