### PR TITLE
Ignore docs-only changes in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,12 @@ name: Coverage
 on:
   push:
     branches: [main, release-*]
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- align coverage trigger with other workflows by ignoring docs/** changes

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test