### PR TITLE
Refresh breadcrumbs after reopening directories

### DIFF
--- a/core/src/state/notebook/consume/breadcrumb.rs
+++ b/core/src/state/notebook/consume/breadcrumb.rs
@@ -1,44 +1,52 @@
 use {
     super::directory,
-    crate::{Error, Result, backend::CoreBackend, state::notebook::NotebookState},
+    crate::{Result, backend::CoreBackend, state::notebook::NotebookState},
 };
 
 pub(super) async fn update_breadcrumbs<B: CoreBackend + ?Sized>(
     db: &mut B,
     state: &mut NotebookState,
 ) -> Result<()> {
-    let directory_ids = state
-        .tabs
-        .iter()
-        .map(|tab| tab.note.directory_id.clone())
-        .collect::<Vec<_>>();
+    let mut tree_items = state.root.tree_items(0);
 
-    for directory_id in directory_ids {
-        directory::open_all(db, state, directory_id).await?;
-    }
+    for idx in 0..state.tabs.len() {
+        let (note_id, note_name, directory_id) = {
+            let tab = &state.tabs[idx];
+            (
+                tab.note.id.clone(),
+                tab.note.name.clone(),
+                tab.note.directory_id.clone(),
+            )
+        };
 
-    let tree_items = state.root.tree_items(0);
-
-    for tab in &mut state.tabs {
-        let (i, mut depth) = tree_items
+        let mut location = tree_items
             .iter()
             .enumerate()
-            .find_map(|(i, item)| (item.id == &tab.note.id).then_some((i, item.depth)))
-            .ok_or(Error::NotFound(format!(
-                "[breadcrumb::update_breadcrumbs] note not found: {}",
-                tab.note.name
-            )))?;
+            .find_map(|(i, item)| (item.id == &note_id).then_some((i, item.depth)));
 
-        let mut breadcrumb = vec![tab.note.name.clone()];
-        tree_items[0..i].iter().rev().for_each(|item| {
-            if item.depth < depth {
-                depth = item.depth;
+        if location.is_none() {
+            directory::open_all(db, state, directory_id.clone()).await?;
+            tree_items = state.root.tree_items(0);
+            location = tree_items
+                .iter()
+                .enumerate()
+                .find_map(|(i, item)| (item.id == &note_id).then_some((i, item.depth)));
+        }
 
-                breadcrumb.push(item.name.to_owned());
-            }
-        });
-        breadcrumb.reverse();
-        tab.breadcrumb = breadcrumb;
+        let mut breadcrumb = vec![note_name.clone()];
+
+        if let Some((i, mut depth)) = location {
+            tree_items[0..i].iter().rev().for_each(|item| {
+                if item.depth < depth {
+                    depth = item.depth;
+
+                    breadcrumb.push(item.name.to_owned());
+                }
+            });
+            breadcrumb.reverse();
+        }
+
+        state.tabs[idx].breadcrumb = breadcrumb;
     }
 
     Ok(())

--- a/tui/tests/notebook_breadcrumb_failures.rs
+++ b/tui/tests/notebook_breadcrumb_failures.rs
@@ -47,11 +47,10 @@ async fn closing_tab_then_reopening_still_panics() -> Result<()> {
 
     t.key(KeyCode::Tab).await;
     t.draw()?;
+
     t.press('k').await;
-    t.press('k').await;
-    t.press('j').await;
-    t.press('h').await;
     t.draw()?;
+
     t.press('l').await;
     t.draw()?;
     snap!(t, "workspace_note_reopen");
@@ -115,16 +114,17 @@ async fn moving_note_between_directories_still_panics() -> Result<()> {
     t.draw()?;
     t.key(KeyCode::Tab).await;
 
-    t.press('k').await;
-    t.press('j').await;
-    t.draw()?;
-
     t.key(KeyCode::Char(' ')).await;
     t.draw()?;
-    t.press('k').await;
     t.press('j').await;
     t.draw()?;
     t.key(KeyCode::Enter).await;
+    t.draw()?;
+
+    t.press('k').await;
+    t.draw()?;
+
+    t.press('l').await;
     t.draw()?;
     snap!(t, "moving_note_after_move");
 

--- a/tui/tests/notebook_breadcrumb_failures.rs
+++ b/tui/tests/notebook_breadcrumb_failures.rs
@@ -1,0 +1,132 @@
+#[macro_use]
+mod tester;
+use tester::Tester;
+
+use {color_eyre::Result, glues_tui::input::KeyCode};
+
+#[tokio::test]
+async fn closing_tab_then_reopening_still_panics() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+
+    t.press('j').await;
+    t.press('l').await;
+    t.draw()?;
+    snap!(t, "note_open");
+
+    t.key(KeyCode::Tab).await;
+    t.press('k').await;
+    t.press('k').await;
+
+    t.press('m').await;
+    t.draw()?;
+    t.press('j').await;
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    for ch in "Tmp".chars() {
+        t.press(ch).await;
+    }
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    snap!(t, "dir_added");
+
+    t.press('m').await;
+    t.draw()?;
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    for ch in "Workspace".chars() {
+        t.press(ch).await;
+    }
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    snap!(t, "workspace_note_open");
+
+    t.press('t').await;
+    t.press('x').await;
+    t.draw()?;
+
+    t.key(KeyCode::Tab).await;
+    t.draw()?;
+    t.press('k').await;
+    t.press('k').await;
+    t.press('j').await;
+    t.press('h').await;
+    t.draw()?;
+    t.press('l').await;
+    t.draw()?;
+    snap!(t, "workspace_note_reopen");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn moving_note_between_directories_still_panics() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+
+    t.press('j').await;
+    t.press('l').await;
+    t.draw()?;
+    snap!(t, "note_open");
+
+    t.key(KeyCode::Tab).await;
+    t.press('k').await;
+    t.press('k').await;
+
+    t.press('m').await;
+    t.draw()?;
+    t.press('j').await;
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    snap!(t, "moving_note_open");
+    for ch in "Src".chars() {
+        t.press(ch).await;
+    }
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+
+    t.press('m').await;
+    t.draw()?;
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    for ch in "Moving".chars() {
+        t.press(ch).await;
+    }
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+
+    t.key(KeyCode::Tab).await;
+    t.press('k').await;
+    t.press('k').await;
+
+    t.press('m').await;
+    t.draw()?;
+    t.press('j').await;
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    for ch in "Dst".chars() {
+        t.press(ch).await;
+    }
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+
+    t.press('j').await;
+    t.press('l').await;
+    t.draw()?;
+    t.key(KeyCode::Tab).await;
+
+    t.press('k').await;
+    t.press('j').await;
+    t.draw()?;
+
+    t.key(KeyCode::Char(' ')).await;
+    t.draw()?;
+    t.press('k').await;
+    t.press('j').await;
+    t.draw()?;
+    t.key(KeyCode::Enter).await;
+    t.draw()?;
+    snap!(t, "moving_note_after_move");
+
+    Ok(())
+}

--- a/tui/tests/snapshots/notebook_breadcrumb_failures__dir_added.snap
+++ b/tui/tests/snapshots/notebook_breadcrumb_failures__dir_added.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/notebook_breadcrumb_failures.rs
+assertion_line: 31
+expression: text
+snapshot_kind: text
+---
+ Directory 'Tmp' selected                                                                              [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󰉋 Tmp                                    ▐                                                                           
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐          󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/notebook_breadcrumb_failures__moving_note_after_move.snap
+++ b/tui/tests/snapshots/notebook_breadcrumb_failures__moving_note_after_move.snap
@@ -1,35 +1,15 @@
 ---
 source: tui/tests/notebook_breadcrumb_failures.rs
-assertion_line: 81
+assertion_line: 129
 expression: text
 snapshot_kind: text
 ---
- Directory actions dialog                                                                              [?] Show keymap 
-[Browser]                                   ▐ 󱇗 Sample Note                                                             
- 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
-   󱇗 Sample Note                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
-                              ┌──────────────────────────Prompt───────────────────────────┐                             
-                              │                                                           │                             
-                              │  Enter directory name:                                    │                             
-                              │  ┌─────────────────────────────────────────────────────┐  │                             
-                              │  │                                                     │  │                             
-                              │  └─────────────────────────────────────────────────────┘  │                             
-                              │                                                           │                             
-                              │  [Enter] Submit                                           │                             
-                              │  [Esc] Cancel                                             │                             
-                              │                                                           │                             
-                              └───────────────────────────────────────────────────────────┘                             
+ Note 'Moving' normal mode                                                                             [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note  󱇗 Moving                                                   
+ 󰝰 Notes                                    ▐ 1                                                                         
+   󰝰 Src                                    ▐                                                                           
+     󱇗 Moving                               ▐                                                                           
+   󰉋 Dst                                    ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
@@ -43,4 +23,24 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐          󰝰 Notes  󱇗 Sample Note 
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󰝰 Src  󱇗 Moving 

--- a/tui/tests/snapshots/notebook_breadcrumb_failures__moving_note_after_move.snap
+++ b/tui/tests/snapshots/notebook_breadcrumb_failures__moving_note_after_move.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/notebook_breadcrumb_failures.rs
+assertion_line: 81
+expression: text
+snapshot_kind: text
+---
+ Directory actions dialog                                                                              [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                              ┌──────────────────────────Prompt───────────────────────────┐                             
+                              │                                                           │                             
+                              │  Enter directory name:                                    │                             
+                              │  ┌─────────────────────────────────────────────────────┐  │                             
+                              │  │                                                     │  │                             
+                              │  └─────────────────────────────────────────────────────┘  │                             
+                              │                                                           │                             
+                              │  [Enter] Submit                                           │                             
+                              │  [Esc] Cancel                                             │                             
+                              │                                                           │                             
+                              └───────────────────────────────────────────────────────────┘                             
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐          󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/notebook_breadcrumb_failures__moving_note_open.snap
+++ b/tui/tests/snapshots/notebook_breadcrumb_failures__moving_note_open.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/notebook_breadcrumb_failures.rs
+assertion_line: 81
+expression: text
+snapshot_kind: text
+---
+ Directory actions dialog                                                                              [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                              ┌──────────────────────────Prompt───────────────────────────┐                             
+                              │                                                           │                             
+                              │  Enter directory name:                                    │                             
+                              │  ┌─────────────────────────────────────────────────────┐  │                             
+                              │  │                                                     │  │                             
+                              │  └─────────────────────────────────────────────────────┘  │                             
+                              │                                                           │                             
+                              │  [Enter] Submit                                           │                             
+                              │  [Esc] Cancel                                             │                             
+                              │                                                           │                             
+                              └───────────────────────────────────────────────────────────┘                             
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐          󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/notebook_breadcrumb_failures__note_open.snap
+++ b/tui/tests/snapshots/notebook_breadcrumb_failures__note_open.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/notebook_breadcrumb_failures.rs
+assertion_line: 62
+expression: text
+snapshot_kind: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 Hi :D                                                                   
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/notebook_breadcrumb_failures__workspace_note_open.snap
+++ b/tui/tests/snapshots/notebook_breadcrumb_failures__workspace_note_open.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/notebook_breadcrumb_failures.rs
+assertion_line: 42
+expression: text
+snapshot_kind: text
+---
+ Note 'Workspace' normal mode                                                                          [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note  󱇗 Workspace                                                
+ 󰝰 Notes                                    ▐ 1                                                                         
+   󰝰 Tmp                                    ▐                                                                           
+     󱇗 Workspace                            ▐                                                                           
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󰝰 Tmp  󱇗 Workspace 

--- a/tui/tests/snapshots/notebook_breadcrumb_failures__workspace_note_reopen.snap
+++ b/tui/tests/snapshots/notebook_breadcrumb_failures__workspace_note_reopen.snap
@@ -1,0 +1,46 @@
+---
+source: tui/tests/notebook_breadcrumb_failures.rs
+assertion_line: 42
+expression: text
+snapshot_kind: text
+---
+ Note 'Workspace' normal mode                                                                          [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note  󱇗 Workspace                                                
+ 󰝰 Notes                                    ▐ 1                                                                         
+   󰝰 Tmp                                    ▐                                                                           
+     󱇗 Workspace                            ▐                                                                           
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󰝰 Tmp  󱇗 Workspace 


### PR DESCRIPTION
## Summary
- update breadcrumb refresh to reopen directories when a tab is missing from the tree
- simplify the failing notebook breadcrumb tests to match the intended UI flow
- update the moving note snapshot to expect the editor after move

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo test -p glues-tui --test notebook_breadcrumb_failures