### PR TITLE
Improve note tree inactive selection contrast

### DIFF
--- a/tui/src/views/body/notebook/note_tree.rs
+++ b/tui/src/views/body/notebook/note_tree.rs
@@ -79,12 +79,12 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut NotebookContext) {
         .bg(if note_tree_focused {
             THEME.accent
         } else {
-            THEME.surface
+            THEME.inactive_bg
         })
         .fg(if note_tree_focused {
             THEME.accent_text
         } else {
-            THEME.text
+            THEME.inactive_text
         });
 
     let list = List::new(tree_items)


### PR DESCRIPTION
## Summary
- switch the note tree's unfocused highlight to use the inactive palette for better contrast

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test