### PR TITLE
Update rust-toolchain to 1.90

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89"
+channel = "1.90"
 components = ["rustfmt", "clippy", "llvm-tools-preview"]


### PR DESCRIPTION
## Summary
- update the workspace rust-toolchain to 1.90 to pick up multi-package publishing support
- no other code changes required for the upgrade

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Rust toolchain to version 1.90 to align with the latest stable release. This maintenance update improves build consistency and long-term compatibility across development environments. There are no changes to features or user workflows, and no action is required from users. Application behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->