### PR TITLE
Add per-crate README assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/gluesql/glues"
+keywords = ["tui", "note-taking", "vim", "ratatui", "data-privacy"]
 
 [workspace.dependencies]
 glues-core = { path = "./core", version = "0.8.0" }

--- a/bin/glues/Cargo.toml
+++ b/bin/glues/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "Unified CLI entry point for the Glues toolkit"
+readme = "../../README.md"
+keywords.workspace = true
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Headless state management module for Glues Notes"
+readme = "README.md"
+keywords.workspace = true
 
 [dependencies]
 async-recursion.workspace = true

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,6 @@
+# glues-core
+
+Core state management and storage abstractions for the Glues note-taking toolkit. This crate implements the headless engine that powers the TUI and server frontends.
+
+For installation instructions and an overview of the project, see the Glues repository README:
+https://github.com/gluesql/glues#readme

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "Glues HTTP proxy server"
+readme = "README.md"
+keywords.workspace = true
 default-run = "glues-server"
 
 [lib]

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,6 @@
+# glues-server
+
+HTTP proxy server for Glues. This binary exposes the same API that the TUI uses locally, enabling remote notebooks and shared deployments.
+
+Configuration and usage details live in the main Glues documentation:
+https://github.com/gluesql/glues#readme

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "TUI and WASM frontends for the Glues note-taking experience"
-readme = "../README.md"
-keywords = ["tui", "note-taking", "vim", "ratatui", "data-privacy"]
+readme = "README.md"
+keywords.workspace = true
 default-run = "glues-tui"
 
 [lib]

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,6 @@
+# glues-tui
+
+Terminal and WebAssembly frontends for Glues. The crate contains the Ratatui-based interface along with the shared logic for the browser build.
+
+Visit the project README for screenshots, installation steps, and storage backends:
+https://github.com/gluesql/glues#readme


### PR DESCRIPTION
## Summary
- add lightweight README.md files for core/server/tui crates so crates.io shows documentation
- reuse the root README for the CLI package
- consolidate common keywords in workspace metadata for consistent tagging

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
