### PR TITLE
Fix README screenshot link to use raw URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Glues is designed with a core architecture that operates independently of the TU
 
 With no reliance on third-party services, Glues ensures that your data remains private and fully under your control. Currently, it ships with Instant (in-memory), Local (file-per-note), redb (single-file), Git, and MongoDB storage options, and we plan to integrate additional backends through [GlueSQL](https://github.com/gluesql/gluesql) for even more flexibility. The core concept behind Glues is to empower users to choose how their data is handled—whether through local files, a redb database file, Git, MongoDB, or future storage options—without any dependence on a central authority. This makes Glues a sync-enabled application that prioritizes user autonomy and privacy.
 
-<img width="1497" alt="Glues workspace view with theme dialog, keymap overlay, and note tree" src="docs/releases/assets/v0.8.0_workspace.png" />
+<img width="1497" alt="Glues workspace view with theme dialog, keymap overlay, and note tree" src="https://raw.githubusercontent.com/gluesql/glues/3bf7b4ac60b1b07e5f7d9824c8357faddaa3722d/docs/releases/assets/v0.8.0_workspace.png" />
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- point README workspace screenshot to raw.githubusercontent.com so crates.io renders it

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to use an absolute URL for the workspace image, ensuring the graphic reliably renders across environments (e.g., GitHub, cloned repositories, and external viewers).
  * Improved consistency and accessibility of documentation assets by removing reliance on a local/relative image path.
  * No functional changes to the application; this update strictly affects documentation presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->