### PR TITLE
Add coverage summary to coverage bot comment

### DIFF
--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -77,6 +77,56 @@ jobs:
           path: coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract coverage summary
+        run: |
+          xz -dc coverage/lcov.info.xz > coverage/lcov.info
+          python3 - <<'PY'
+import os
+
+lf_hits = 0
+lf_found = 0
+da_hits = 0
+da_found = 0
+
+with open("coverage/lcov.info") as handle:
+    for raw_line in handle:
+        line = raw_line.strip()
+        if line.startswith("LF:"):
+            try:
+                lf_found += int(line[3:])
+            except ValueError:
+                pass
+        elif line.startswith("LH:"):
+            try:
+                lf_hits += int(line[3:])
+            except ValueError:
+                pass
+        elif line.startswith("DA:"):
+            parts = line[3:].split(",")
+            if len(parts) >= 2:
+                da_found += 1
+                try:
+                    count = int(parts[1])
+                except ValueError:
+                    count = 0
+                if count > 0:
+                    da_hits += 1
+
+if lf_found == 0:
+    lf_found, lf_hits = da_found, da_hits
+
+coverage = 0.0 if lf_found == 0 else (lf_hits / lf_found) * 100.0
+
+env_path = os.environ.get("GITHUB_ENV")
+if env_path:
+    with open(env_path, "a") as env_file:
+        env_file.write(f"LINE_COVERAGE={coverage:.2f}\n")
+        env_file.write(f"LINE_HITS={lf_hits}\n")
+        env_file.write(f"LINE_FOUND={lf_found}\n")
+
+print(f"Line coverage: {coverage:.2f}% ({lf_hits}/{lf_found})")
+PY
+
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
 
@@ -99,13 +149,23 @@ jobs:
           script: |
             const prNumber = process.env.PR_NUMBER;
             const url = `https://gluesql.org/coverage/?path=glues/pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;
-            const body = [
+            let body = [
               '### Glues Coverage Report',
               '',
               `- **Commit:** \`${process.env.COMMIT_SHA}\``,
               `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
               `- **Report:** [View report](${url})`
             ].join('\n');
+            const lineCoverage = process.env.LINE_COVERAGE;
+            const lineHits = process.env.LINE_HITS;
+            const lineFound = process.env.LINE_FOUND;
+            if (lineCoverage) {
+              const coverageLine = `- **Line Coverage:** ${lineCoverage}% (${lineHits}/${lineFound})`;
+              if (!body.includes(coverageLine)) {
+                // Append coverage details once per update
+                body = [body, coverageLine].join('\n');
+              }
+            }
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {


### PR DESCRIPTION
## Summary
- coverage 워크플로에서 lcov 압축 파일을 풀고 전체 라인 커버리지 수치를 추출합니다
- PR 코멘트에 커버리지 링크와 함께 라인 커버리지 퍼센트와 히트/전체 라인 수를 표시합니다

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
