### PR TITLE
Replace tui-textarea with tui-input for prompt widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
  "textwrap",
  "tokio",
  "tui-big-text",
+ "tui-input",
  "tui-textarea",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4248,6 +4249,15 @@ dependencies = [
  "font8x8",
  "itertools 0.14.0",
  "ratatui-core",
+]
+
+[[package]]
+name = "tui-input"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c1ee964298f136020f5f69e0e601f4d3a1f610a7baf1af9fcb96152e8a2c45"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -19,6 +19,7 @@ glues-core.workspace = true
 async-recursion.workspace = true
 color-eyre = "0.6.3"
 tui-big-text = "0.8.2"
+tui-input = { version = "0.15.0", default-features = false }
 tui-textarea = { git = "https://github.com/0xferrous/tui-textarea.git", branch = "update-ratatui", default-features = false, features = ["ratatui"] }
 textwrap = "0.16"
 

--- a/tui/tests/snapshots/notebook_tree__note_renamed.snap
+++ b/tui/tests/snapshots/notebook_tree__note_renamed.snap
@@ -4,10 +4,10 @@ assertion_line: 170
 expression: text
 snapshot_kind: text
 ---
- Note 'RenamedSample Note' selected                                                                    [?] Show keymap 
+ Note 'Renamed' selected                                                                               [?] Show keymap 
 [Browser]                                   ▐[Editor]                                                                   
  󰝰 Notes                                    ▐ 1 Welcome to Glues!                                                       
-   󱇗 RenamedSample Note                     ▐ 2                                                                         
+   󱇗 Renamed                                ▐ 2                                                                         
                                             ▐ 3 Press `?` to see keymaps and shortcuts.                                 
                                             ▐ 4 Press `m` in the note tree to create notes or directories.              
                                             ▐ 5 Press `Enter` on a note to open it and start writing.                   

--- a/tui/tests/snapshots/notebook_views__editor_breadcrumb_nested.snap
+++ b/tui/tests/snapshots/notebook_views__editor_breadcrumb_nested.snap
@@ -1,14 +1,14 @@
 ---
 source: tui/tests/notebook_views.rs
-assertion_line: 118
+assertion_line: 123
 expression: text
 snapshot_kind: text
 ---
- Note 'SecondSample Note' normal mode                                                                  [?] Show keymap 
-[Browser]                                   ▐ 󱇗 SecondSample Note                                                       
+ Note 'Sample NoteSecond' normal mode                                                                  [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample NoteSecond                                                       
  󰝰 Notes                                    ▐ 1 XHted                                                                   
    󰉋 Dir                                    ▐ 2 jl :D                                                                   
-   󱇗 SecondSample Note                      ▐                                                                           
+   󱇗 Sample NoteSecond                      ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           

--- a/tui/tests/snapshots/notebook_views__editor_inactive.snap
+++ b/tui/tests/snapshots/notebook_views__editor_inactive.snap
@@ -4,11 +4,11 @@ assertion_line: 128
 expression: text
 snapshot_kind: text
 ---
- Note 'SecondSample Note' selected                                                                     [?] Show keymap 
+ Note 'Sample NoteSecond' selected                                                                     [?] Show keymap 
 [Browser]                                   ▐[Editor]                                                                   
  󰝰 Notes                                    ▐ 1 Welcome to Glues!                                                       
    󰉋 Dir                                    ▐ 2                                                                         
-   󱇗 SecondSample Note                      ▐ 3 Press `?` to see keymaps and shortcuts.                                 
+   󱇗 Sample NoteSecond                      ▐ 3 Press `?` to see keymaps and shortcuts.                                 
                                             ▐ 4 Press `m` in the note tree to create notes or directories.              
                                             ▐ 5 Press `Enter` on a note to open it and start writing.                   
                                             ▐ 6                                                                         

--- a/tui/tests/snapshots/notebook_views__editor_tab_tree.snap
+++ b/tui/tests/snapshots/notebook_views__editor_tab_tree.snap
@@ -1,13 +1,13 @@
 ---
 source: tui/tests/notebook_views.rs
-assertion_line: 87
+assertion_line: 92
 expression: text
 snapshot_kind: text
 ---
- Note 'SecondSample Note' selected                                                                     [?] Show keymap 
-[Browser]                                   ▐ 󱇗 SecondSample Note  󱇗 Other                                              
+ Note 'Sample NoteSecond' selected                                                                     [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample NoteSecond  󱇗 Other                                              
  󰝰 Notes                                    ▐ 1 XHi :D                                                                  
-   󱇗 SecondSample Note                      ▐                                                                           
+   󱇗 Sample NoteSecond                      ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
@@ -43,4 +43,4 @@ snapshot_kind: text
                                             ▐                                                                           
                                             ▐                                                                           
                                             ▐                                                                           
-                                            ▐          󰝰 Notes  󱇗 SecondSample Note 
+                                            ▐          󰝰 Notes  󱇗 Sample NoteSecond 


### PR DESCRIPTION
ContextPrompt was using TextArea for single-line text input.
Switch to the lighter tui-input crate and render manually with Paragraph + cursor positioning.
tui-textarea remains for the notebook editor only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced terminal UI input widget with improved rendering, cursor positioning, and text masking capabilities for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->