### PR TITLE
Add word-wrap support to notebook editor

### DIFF
--- a/tui/src/views/body/notebook/editor.rs
+++ b/tui/src/views/body/notebook/editor.rs
@@ -64,7 +64,7 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
         let editor = context.notebook.get_editor_mut();
         EditorView::new(editor)
             .theme(theme)
-            .wrap(false)
+            .wrap(true)
             .line_numbers(line_numbers)
             .render(area, frame.buffer_mut());
 
@@ -76,7 +76,7 @@ pub fn draw(frame: &mut Frame, area: Rect, context: &mut Context) {
         let theme = theme.hide_cursor();
         EditorView::new(&mut sample_state)
             .theme(theme)
-            .wrap(false)
+            .wrap(true)
             .line_numbers(line_numbers)
             .render(area, frame.buffer_mut());
     };
@@ -231,7 +231,7 @@ fn prepare_scroll_viewport(context: &mut Context, area: Rect) -> usize {
     let mut scratch = Buffer::empty(area);
     EditorView::new(editor)
         .theme(scratch_theme())
-        .wrap(false)
+        .wrap(true)
         .render(area, &mut scratch);
 
     // Pre-render 2: scroll viewport to best possible position
@@ -240,7 +240,7 @@ fn prepare_scroll_viewport(context: &mut Context, area: Rect) -> usize {
     let mut scratch = Buffer::empty(area);
     EditorView::new(editor)
         .theme(scratch_theme())
-        .wrap(false)
+        .wrap(true)
         .render(area, &mut scratch);
 
     // Restore cursor

--- a/tui/tests/editor_wrap.rs
+++ b/tui/tests/editor_wrap.rs
@@ -1,0 +1,156 @@
+#[macro_use]
+mod tester;
+use tester::Tester;
+
+use color_eyre::Result;
+use glues_tui::input::KeyCode;
+
+#[tokio::test]
+async fn long_line_wraps() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    // delete default content and type a long line (120 chars) that exceeds editor width (~74 chars)
+    t.press('d').await;
+    t.press('d').await;
+    t.press('i').await;
+    t.type_str(&"abcdefgh".repeat(15)).await;
+    t.draw()?;
+    snap!(t, "long_line_wraps");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multiple_long_lines_wrap() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    // delete default content
+    t.press('d').await;
+    t.press('d').await;
+    t.press('i').await;
+
+    // type three long lines separated by Enter
+    for i in 0..3 {
+        let ch = (b'A' + i) as char;
+        t.type_str(&format!("{ch}").repeat(100)).await;
+        if i < 2 {
+            t.key(KeyCode::Enter).await;
+        }
+    }
+
+    t.draw()?;
+    snap!(t, "multiple_long_lines_wrap");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn cursor_on_wrapped_line() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    // delete default content and type a long line
+    t.press('d').await;
+    t.press('d').await;
+    t.press('i').await;
+    t.type_str(&"abcdefgh".repeat(15)).await;
+
+    // return to normal mode so cursor is visible on the wrapped line
+    t.key(KeyCode::Esc).await;
+    t.draw()?;
+    snap!(t, "cursor_on_wrapped_line");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_word_on_wrapped_line() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    // replace default content with a long line
+    t.press('d').await;
+    t.press('d').await;
+    t.press('i').await;
+    t.type_str("abcdefgh ".repeat(12).trim_end()).await;
+    t.key(KeyCode::Esc).await;
+
+    // go to beginning and delete a word with dw
+    t.press('0').await;
+    t.draw()?;
+    snap!(t, "dw_before");
+
+    t.press('d').await;
+    t.press('w').await;
+    t.draw()?;
+    snap!(t, "dw_after");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn dd_on_wrapped_lines() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    // replace default content with two long lines
+    t.press('d').await;
+    t.press('d').await;
+    t.press('i').await;
+    t.type_str(&"A".repeat(100)).await;
+    t.key(KeyCode::Enter).await;
+    t.type_str(&"B".repeat(100)).await;
+    t.key(KeyCode::Esc).await;
+
+    // go to first line
+    t.press('g').await;
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "dd_before");
+
+    // dd deletes the entire first wrapped line
+    t.press('d').await;
+    t.press('d').await;
+    t.draw()?;
+    snap!(t, "dd_after");
+
+    // undo restores it
+    t.press('u').await;
+    t.draw()?;
+    snap!(t, "dd_undo");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn insert_middle_of_wrapped_line() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    // replace default content with a long line
+    t.press('d').await;
+    t.press('d').await;
+    t.press('i').await;
+    t.type_str(&"X".repeat(100)).await;
+    t.key(KeyCode::Esc).await;
+
+    // move cursor to middle of line and insert text
+    t.press('0').await;
+    for _ in 0..50 {
+        t.press('l').await;
+    }
+    t.press('i').await;
+    t.type_str("INSERTED").await;
+    t.draw()?;
+    snap!(t, "insert_middle_wrapped");
+
+    Ok(())
+}

--- a/tui/tests/snapshots/editor_wrap__cursor_on_wrapped_line.snap
+++ b/tui/tests/snapshots/editor_wrap__cursor_on_wrapped_line.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh
+   󱇗 Sample Note                            ▐   abcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh                        
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__dd_after.snap
+++ b/tui/tests/snapshots/editor_wrap__dd_after.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+   󱇗 Sample Note                            ▐   BBBBBBBBBBBBBBBBBBBBBBBBBBBB                                            
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__dd_before.snap
+++ b/tui/tests/snapshots/editor_wrap__dd_before.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+   󱇗 Sample Note                            ▐   AAAAAAAAAAAAAAAAAAAAAAAAAAAA                                            
+                                            ▐ 2 BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+                                            ▐   BBBBBBBBBBBBBBBBBBBBBBBBBBBB                                            
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__dd_undo.snap
+++ b/tui/tests/snapshots/editor_wrap__dd_undo.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+   󱇗 Sample Note                            ▐   AAAAAAAAAAAAAAAAAAAAAAAAAAAA                                            
+                                            ▐ 2 BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+                                            ▐   BBBBBBBBBBBBBBBBBBBBBBBBBBBB                                            
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__dw_after.snap
+++ b/tui/tests/snapshots/editor_wrap__dw_after.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh 
+   󱇗 Sample Note                            ▐   abcdefgh abcdefgh abcdefgh abcdefgh                                     
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__dw_before.snap
+++ b/tui/tests/snapshots/editor_wrap__dw_before.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh 
+   󱇗 Sample Note                            ▐   abcdefgh abcdefgh abcdefgh abcdefgh                                     
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__insert_middle_wrapped.snap
+++ b/tui/tests/snapshots/editor_wrap__insert_middle_wrapped.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' insert mode                                                                   [Ctrl+h] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXINSERTEDXXXXXXXXXXXXXX
+   󱇗 Sample Note                            ▐   XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                                    
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ INSERT   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__long_line_wraps.snap
+++ b/tui/tests/snapshots/editor_wrap__long_line_wraps.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' insert mode                                                                   [Ctrl+h] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh
+   󱇗 Sample Note                            ▐   abcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh                        
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ INSERT   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...

--- a/tui/tests/snapshots/editor_wrap__multiple_long_lines_wrap.snap
+++ b/tui/tests/snapshots/editor_wrap__multiple_long_lines_wrap.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_wrap.rs
+expression: text
+---
+ Note 'Sample Note' insert mode                                                                   [Ctrl+h] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 1 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+   󱇗 Sample Note                            ▐   AAAAAAAAAAAAAAAAAAAAAAAAAAAA                                            
+                                            ▐ 2 BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+                                            ▐   BBBBBBBBBBBBBBBBBBBBBBBBBBBB                                            
+                                            ▐ 3 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+                                            ▐   CCCCCCCCCCCCCCCCCCCCCCCCCCCC                                            
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ INSERT   󰝰 Notes  󱇗 Sample Note                           󰔚 Saving...


### PR DESCRIPTION
Ref #282

## Summary
- Apply `.wrap(true)` to the editor so long lines wrap within the viewport instead of rendering off-screen
- Add 6 snapshot tests covering wrap rendering (single/multiple long lines, cursor position) and editing on wrapped lines (dw, dd/undo, mid-line insertion)

## Test plan
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo test --workspace` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled line wrapping throughout the editor interface to improve content visibility and readability across all editing contexts.

* **Tests**
  * Added comprehensive test suite validating editor line wrapping functionality, including cursor positioning, text insertion, deletion operations on wrapped content, and multi-line text handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->