### PR TITLE
Fix viewport jump after zz/zt/zb scroll commands

### DIFF
--- a/tui/src/context/notebook.rs
+++ b/tui/src/context/notebook.rs
@@ -101,6 +101,9 @@ pub struct NotebookContext {
 
     /// Pending scroll request to be applied at render time.
     pub pending_scroll: Option<ScrollRequest>,
+
+    /// Persistent anchor for maintaining buffer shift across frames.
+    pub scroll_anchor: Option<ScrollAnchor>,
 }
 
 #[derive(Clone, Copy)]
@@ -108,6 +111,14 @@ pub enum ScrollRequest {
     Center,
     Top,
     Bottom,
+}
+
+#[derive(Clone, Copy)]
+pub struct ScrollAnchor {
+    /// Desired top row of the virtual viewport
+    pub desired_top: usize,
+    /// The actual viewport.y set by the initial pre-renders (edtui's clamped position)
+    pub actual_viewport_y: usize,
 }
 
 pub struct EditorItem {
@@ -138,6 +149,7 @@ impl Default for NotebookContext {
             line_yanked: false,
             yank: None,
             pending_scroll: None,
+            scroll_anchor: None,
         }
     }
 }

--- a/tui/src/transitions/notebook.rs
+++ b/tui/src/transitions/notebook.rs
@@ -56,6 +56,7 @@ impl App {
 
         if &self.context.notebook.tab_index != tab_index {
             self.context.notebook.tab_index = *tab_index;
+            self.context.notebook.scroll_anchor = None;
         }
 
         match transition {

--- a/tui/tests/editor_normal.rs
+++ b/tui/tests/editor_normal.rs
@@ -191,74 +191,6 @@ async fn change_inside_word() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn gateway_moves_cursor_to_top() -> Result<()> {
-    let mut t = Tester::new().await?;
-    t.open_instant().await?;
-    t.open_first_note().await?;
-
-    populate_long_note(&mut t).await?;
-    t.draw()?;
-
-    // Move to bottom so the gateway jump visibly changes the view.
-    t.press('G').await;
-
-    // First 'g' enters gateway mode.
-    t.press('g').await;
-    t.draw()?;
-    snap!(t, "gateway_prompt");
-
-    // Second 'g' jumps to the top line.
-    t.press('g').await;
-    t.draw()?;
-    snap!(t, "gateway_move_top");
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn scroll_commands_update_view() -> Result<()> {
-    let mut t = Tester::new().await?;
-    t.open_instant().await?;
-    t.open_first_note().await?;
-
-    populate_long_note(&mut t).await?;
-    t.draw()?;
-
-    // Start near the middle of the document.
-    t.press('g').await;
-    t.press('g').await;
-    for _ in 0..20 {
-        t.press('j').await;
-    }
-
-    t.press('z').await;
-    t.draw()?;
-    snap!(t, "scroll_prompt");
-
-    t.press('t').await;
-    t.draw()?;
-    snap!(t, "scroll_jump_top");
-
-    // Jump to bottom and use 'zb'.
-    t.press('G').await;
-    t.press('z').await;
-    t.press('b').await;
-    t.draw()?;
-    snap!(t, "scroll_jump_bottom");
-
-    // Move back toward the middle and center with 'z.'.
-    for _ in 0..15 {
-        t.press('k').await;
-    }
-    t.press('z').await;
-    t.press('.').await;
-    t.draw()?;
-    snap!(t, "scroll_jump_center");
-
-    Ok(())
-}
-
 async fn populate_long_note(tester: &mut Tester) -> Result<()> {
     let lines: Vec<String> = (1..=60)
         .map(|i| format!("Line {i:02} — the quick brown fox jumps over the lazy dog."))
@@ -282,6 +214,31 @@ async fn populate_long_note(tester: &mut Tester) -> Result<()> {
     tester.key(KeyCode::Tab).await;
     tester.draw()?;
     tester.key(KeyCode::Tab).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn gateway_moves_cursor_to_top() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    populate_long_note(&mut t).await?;
+    t.draw()?;
+
+    // Move to bottom so the gateway jump visibly changes the view.
+    t.press('G').await;
+
+    // First 'g' enters gateway mode.
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "gateway_prompt");
+
+    // Second 'g' jumps to the top line.
+    t.press('g').await;
+    t.draw()?;
+    snap!(t, "gateway_move_top");
 
     Ok(())
 }

--- a/tui/tests/editor_viewport.rs
+++ b/tui/tests/editor_viewport.rs
@@ -1,0 +1,183 @@
+#[macro_use]
+mod tester;
+use tester::Tester;
+
+use color_eyre::Result;
+use glues_tui::input::KeyCode;
+
+async fn populate_long_note(tester: &mut Tester) -> Result<()> {
+    let lines: Vec<String> = (1..=60)
+        .map(|i| format!("Line {i:02} — the quick brown fox jumps over the lazy dog."))
+        .collect();
+
+    tester.press('g').await;
+    tester.press('g').await;
+
+    tester.press('d').await;
+    tester.press('d').await;
+
+    tester.press('i').await;
+    for (idx, line) in lines.iter().enumerate() {
+        tester.type_str(line).await;
+        if idx + 1 < lines.len() {
+            tester.key(KeyCode::Enter).await;
+        }
+    }
+    tester.key(KeyCode::Esc).await;
+
+    tester.key(KeyCode::Tab).await;
+    tester.draw()?;
+    tester.key(KeyCode::Tab).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn scroll_commands_update_view() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    populate_long_note(&mut t).await?;
+    t.draw()?;
+
+    // Start near the middle of the document.
+    t.press('g').await;
+    t.press('g').await;
+    for _ in 0..20 {
+        t.press('j').await;
+    }
+
+    t.press('z').await;
+    t.draw()?;
+    snap!(t, "scroll_prompt");
+
+    t.press('t').await;
+    t.draw()?;
+    snap!(t, "scroll_jump_top");
+
+    // Jump to bottom and use 'zb'.
+    t.press('G').await;
+    t.press('z').await;
+    t.press('b').await;
+    t.draw()?;
+    snap!(t, "scroll_jump_bottom");
+
+    // Move back toward the middle and center with 'z.'.
+    for _ in 0..15 {
+        t.press('k').await;
+    }
+    t.press('z').await;
+    t.press('.').await;
+    t.draw()?;
+    snap!(t, "scroll_jump_center");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn scroll_zt_then_jk_stable_viewport() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    populate_long_note(&mut t).await?;
+
+    // Go to end of document
+    t.press('G').await;
+
+    // zt: scroll cursor line to top
+    t.press('z').await;
+    t.press('t').await;
+    t.draw()?;
+    snap!(t, "zt_at_bottom");
+
+    // j at last line (cursor stays, viewport must not jump)
+    t.press('j').await;
+    t.draw()?;
+    snap!(t, "zt_at_bottom_after_j");
+
+    // k moves cursor up one line, viewport stays stable
+    t.press('k').await;
+    t.draw()?;
+    snap!(t, "zt_at_bottom_after_k");
+
+    // k 4 more times
+    for _ in 0..4 {
+        t.press('k').await;
+    }
+    t.draw()?;
+    snap!(t, "zt_at_bottom_after_5k");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn scroll_zt_then_k_releases_anchor() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    populate_long_note(&mut t).await?;
+
+    // Go to end and zt
+    t.press('G').await;
+    t.press('z').await;
+    t.press('t').await;
+    t.draw()?;
+    snap!(t, "zt_release_start");
+
+    // k 20 times — cursor moves up enough to release anchor
+    for _ in 0..20 {
+        t.press('k').await;
+    }
+    t.draw()?;
+    snap!(t, "zt_release_after_20k");
+
+    // j 5 times — anchor released, normal viewport behavior
+    for _ in 0..5 {
+        t.press('j').await;
+    }
+    t.draw()?;
+    snap!(t, "zt_release_after_j");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn scroll_zz_midfile_jk_no_shift() -> Result<()> {
+    let mut t = Tester::new().await?;
+    t.open_instant().await?;
+    t.open_first_note().await?;
+
+    populate_long_note(&mut t).await?;
+
+    // Go to top, then move to row 20
+    t.press('g').await;
+    t.press('g').await;
+    for _ in 0..20 {
+        t.press('j').await;
+    }
+
+    // zz (z.)
+    t.press('z').await;
+    t.press('.').await;
+    t.draw()?;
+    snap!(t, "zz_mid_start");
+
+    // j 3 times
+    for _ in 0..3 {
+        t.press('j').await;
+    }
+    t.draw()?;
+    snap!(t, "zz_mid_after_3j");
+
+    // k 3 times — back to original position
+    for _ in 0..3 {
+        t.press('k').await;
+    }
+    t.draw()?;
+    snap!(t, "zz_mid_after_3k");
+
+    Ok(())
+}

--- a/tui/tests/snapshots/editor_viewport__scroll_jump_bottom.snap
+++ b/tui/tests/snapshots/editor_viewport__scroll_jump_bottom.snap
@@ -1,16 +1,13 @@
 ---
-source: tui/tests/editor_normal.rs
-assertion_line: 152
+source: tui/tests/editor_viewport.rs
+assertion_line: 162
 expression: text
 snapshot_kind: text
 ---
- Note 'Sample Note' normal mode - scroll                                                               [?] Show keymap 
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
 [Browser]                                   ▐ 󱇗 Sample Note                                                             
- 󰝰 Notes                                    ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
-   󱇗 Sample Note                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+ 󰝰 Notes                                    ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
@@ -43,4 +40,7 @@ snapshot_kind: text
                                             ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__scroll_jump_center.snap
+++ b/tui/tests/snapshots/editor_viewport__scroll_jump_center.snap
@@ -1,16 +1,13 @@
 ---
-source: tui/tests/editor_normal.rs
-assertion_line: 162
+source: tui/tests/editor_viewport.rs
+assertion_line: 171
 expression: text
 snapshot_kind: text
 ---
  Note 'Sample Note' normal mode                                                                        [?] Show keymap 
 [Browser]                                   ▐ 󱇗 Sample Note                                                             
- 󰝰 Notes                                    ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
-   󱇗 Sample Note                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+ 󰝰 Notes                                    ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
@@ -43,4 +40,7 @@ snapshot_kind: text
                                             ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
                                             ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__scroll_jump_top.snap
+++ b/tui/tests/snapshots/editor_viewport__scroll_jump_top.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/tests/editor_normal.rs
+source: tui/tests/editor_viewport.rs
 assertion_line: 155
 expression: text
 snapshot_kind: text

--- a/tui/tests/snapshots/editor_viewport__scroll_prompt.snap
+++ b/tui/tests/snapshots/editor_viewport__scroll_prompt.snap
@@ -1,13 +1,19 @@
 ---
-source: tui/tests/editor_normal.rs
-assertion_line: 171
+source: tui/tests/editor_viewport.rs
+assertion_line: 152
 expression: text
 snapshot_kind: text
 ---
- Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+ Note 'Sample Note' normal mode - scroll                                                               [?] Show keymap 
 [Browser]                                   ▐ 󱇗 Sample Note                                                             
- 󰝰 Notes                                    ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
-   󱇗 Sample Note                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+ 󰝰 Notes                                    ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
@@ -37,10 +43,4 @@ snapshot_kind: text
                                             ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
                                             ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
-                                            ▐                                                                           
-                                            ▐                                                                           
-                                            ▐                                                                           
                                             ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zt_at_bottom.snap
+++ b/tui/tests/snapshots/editor_viewport__zt_at_bottom.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zt_at_bottom_after_5k.snap
+++ b/tui/tests/snapshots/editor_viewport__zt_at_bottom_after_5k.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zt_at_bottom_after_j.snap
+++ b/tui/tests/snapshots/editor_viewport__zt_at_bottom_after_j.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zt_at_bottom_after_k.snap
+++ b/tui/tests/snapshots/editor_viewport__zt_at_bottom_after_k.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zt_release_after_20k.snap
+++ b/tui/tests/snapshots/editor_viewport__zt_release_after_20k.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 40 Line 40 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 41 Line 41 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 42 Line 42 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 43 Line 43 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 44 Line 44 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 45 Line 45 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 46 Line 46 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 47 Line 47 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 48 Line 48 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 49 Line 49 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 50 Line 50 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 51 Line 51 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 52 Line 52 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 53 Line 53 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 54 Line 54 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zt_release_after_j.snap
+++ b/tui/tests/snapshots/editor_viewport__zt_release_after_j.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 40 Line 40 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐ 41 Line 41 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 42 Line 42 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 43 Line 43 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 44 Line 44 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 45 Line 45 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 46 Line 46 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 47 Line 47 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 48 Line 48 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 49 Line 49 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 50 Line 50 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 51 Line 51 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 52 Line 52 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 53 Line 53 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 54 Line 54 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 55 Line 55 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 56 Line 56 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 57 Line 57 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 58 Line 58 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 59 Line 59 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zt_release_start.snap
+++ b/tui/tests/snapshots/editor_viewport__zt_release_start.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐ 60 Line 60 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐                                                                           
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zz_mid_after_3j.snap
+++ b/tui/tests/snapshots/editor_viewport__zz_mid_after_3j.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐  3 Line 03 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐  4 Line 04 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  5 Line 05 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  6 Line 06 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  7 Line 07 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  8 Line 08 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  9 Line 09 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 10 Line 10 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 11 Line 11 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 12 Line 12 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 13 Line 13 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 14 Line 14 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 15 Line 15 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 16 Line 16 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 17 Line 17 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 18 Line 18 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 19 Line 19 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 20 Line 20 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zz_mid_after_3k.snap
+++ b/tui/tests/snapshots/editor_viewport__zz_mid_after_3k.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐  3 Line 03 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐  4 Line 04 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  5 Line 05 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  6 Line 06 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  7 Line 07 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  8 Line 08 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  9 Line 09 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 10 Line 10 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 11 Line 11 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 12 Line 12 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 13 Line 13 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 14 Line 14 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 15 Line 15 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 16 Line 16 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 17 Line 17 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 18 Line 18 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 19 Line 19 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 20 Line 20 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 

--- a/tui/tests/snapshots/editor_viewport__zz_mid_start.snap
+++ b/tui/tests/snapshots/editor_viewport__zz_mid_start.snap
@@ -1,0 +1,44 @@
+---
+source: tui/tests/editor_viewport.rs
+expression: text
+---
+ Note 'Sample Note' normal mode                                                                        [?] Show keymap 
+[Browser]                                   ▐ 󱇗 Sample Note                                                             
+ 󰝰 Notes                                    ▐  3 Line 03 — the quick brown fox jumps over the lazy dog.                 
+   󱇗 Sample Note                            ▐  4 Line 04 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  5 Line 05 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  6 Line 06 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  7 Line 07 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  8 Line 08 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐  9 Line 09 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 10 Line 10 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 11 Line 11 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 12 Line 12 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 13 Line 13 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 14 Line 14 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 15 Line 15 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 16 Line 16 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 17 Line 17 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 18 Line 18 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 19 Line 19 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 20 Line 20 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 21 Line 21 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 22 Line 22 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 23 Line 23 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 24 Line 24 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 25 Line 25 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 26 Line 26 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 27 Line 27 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 28 Line 28 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 29 Line 29 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 30 Line 30 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 31 Line 31 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 32 Line 32 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 33 Line 33 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 34 Line 34 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 35 Line 35 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 36 Line 36 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 37 Line 37 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 38 Line 38 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ 39 Line 39 — the quick brown fox jumps over the lazy dog.                 
+                                            ▐ NORMAL   󰝰 Notes  󱇗 Sample Note 


### PR DESCRIPTION
## Summary
- Fix viewport snapping back after `j`/`k` movement following `zz`/`zt`/`zb` scroll commands
- Introduce `ScrollAnchor` to persist buffer shift across frames, dynamically adjusting as the cursor moves
- Extract scroll/viewport tests from `editor_normal` into a dedicated `editor_viewport` test file

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` all 97 tests pass
- [x] Existing `scroll_commands_update_view` snapshots unchanged
- [x] `scroll_zt_then_jk_stable_viewport` — viewport stays stable after j/k with active shift
- [x] `scroll_zt_then_k_releases_anchor` — anchor auto-releases after enough k presses
- [x] `scroll_zz_midfile_jk_no_shift` — regression test for mid-document zz (shift=0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent scroll anchoring to keep the editor viewport stable across scroll commands and interactions.
* **Bug Fixes**
  * Anchor state is cleared when switching tabs to avoid stale viewport positioning.
* **Tests**
  * Added comprehensive integration tests covering scrolling commands, anchoring behavior, and viewport stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->