### PR TITLE
Add Nix flake for reproducible builds, dev shell and checks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,135 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1775839657,
+        "narHash": "sha256-SPm9ck7jh3Un9nwPuMGbRU04UroFmOHjLP56T10MOeM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7cf72d978629469c4bd4206b95c402514c1f6000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776050130,
+        "narHash": "sha256-/f/6/1WOfBJaGMfqV3VxWD9lpFRbPpF+Cx4MO+0mGok=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3c27f4c92a7d977556dd2c10bb564d9c61b375e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,208 @@
+{
+  description = "Glues - terminal note-taking toolkit (TUI, core, server)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # Modern Rust build framework with split dependency / workspace caching.
+    crane.url = "github:ipetkov/crane";
+
+    # Unified formatter integration (runs on Nix files only here - Rust and
+    # TOML formatting is left to `cargo fmt` / `taplo` from the dev shell
+    # so the flake never rewrites upstream-owned source).
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+
+      imports = [
+        inputs.treefmt-nix.flakeModule
+      ];
+
+      # Flake-wide outputs. Exposing an overlay lets downstream flakes pull
+      # glues in via `overlays = [ glues.overlays.default ]`.
+      flake = {
+        overlays.default = _final: prev: {
+          glues = self.packages.${prev.stdenv.hostPlatform.system}.glues;
+        };
+      };
+
+      perSystem = { config, system, lib, ... }:
+        let
+          pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ inputs.rust-overlay.overlays.default ];
+          };
+
+          # Respect the project's rust-toolchain.toml (channel 1.93, plus
+          # rustfmt / clippy / llvm-tools-preview). A single source of
+          # truth for the Rust version used by package, checks and shell.
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          workspaceCargoToml = lib.importTOML ./Cargo.toml;
+          binCargoToml = lib.importTOML ./bin/glues/Cargo.toml;
+
+          # Minimal source: only inputs cargo actually needs to build the
+          # workspace. Editing README.md, docs, CI, AGENTS.md or the flake
+          # itself no longer busts the build cache.
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./Cargo.toml
+              ./Cargo.lock
+              ./bin
+              ./core
+              ./server
+              ./tui
+            ];
+          };
+
+          nativeBuildInputs = [ pkgs.pkg-config ];
+
+          # openssl-sys is pulled in transitively via reqwest's blocking
+          # feature. Darwin additionally links several Apple SDK frameworks
+          # (native-tls, arboard, tokio signals).
+          buildInputs = with pkgs;
+            [ openssl zlib ]
+            ++ lib.optionals stdenv.hostPlatform.isDarwin (
+              [ libiconv ]
+              ++ (with pkgs.darwin.apple_sdk.frameworks; [
+                AppKit
+                Cocoa
+                CoreFoundation
+                Security
+                SystemConfiguration
+              ])
+            );
+
+          # Shared args for every crane invocation. All derivations - the
+          # package, clippy, nextest, audit - share one dependency build
+          # via `cargoArtifacts`.
+          commonArgs = {
+            inherit src nativeBuildInputs buildInputs;
+            pname = "glues-workspace";
+            version = workspaceCargoToml.workspace.package.version;
+
+            strictDeps = true;
+
+            # Prefer the system OpenSSL over the vendored copy.
+            OPENSSL_NO_VENDOR = "1";
+          };
+
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+          glues = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+
+            pname = "glues";
+            # Build every workspace binary (glues, glues-tui, glues-server).
+            cargoExtraArgs = "--workspace --bins";
+
+            # Tests run in a dedicated nextest check below; `nix build`
+            # stays focused on producing the binaries.
+            doCheck = false;
+
+            meta = {
+              description = lib.strings.removeSuffix "." binCargoToml.package.description;
+              homepage = workspaceCargoToml.workspace.package.repository;
+              changelog = "${workspaceCargoToml.workspace.package.repository}/releases";
+              license = lib.licenses.asl20;
+              mainProgram = "glues";
+              platforms = lib.platforms.unix;
+            };
+          });
+        in
+        {
+          # Share the overlay-augmented pkgs with sibling flake-parts
+          # modules (treefmt-nix) so there is exactly one nixpkgs instance.
+          _module.args.pkgs = pkgs;
+
+          packages = {
+            default = glues;
+            glues = glues;
+          };
+
+          apps.default = {
+            type = "app";
+            program = lib.getExe glues;
+          };
+
+          devShells.default = pkgs.mkShell {
+            inherit nativeBuildInputs buildInputs;
+
+            packages = with pkgs; [
+              rustToolchain
+              # rust-toolchain.toml omits these, so expose them here for
+              # editor integrations and coverage workflow from AGENTS.md.
+              rust-analyzer
+              cargo-llvm-cov
+              # Cargo ergonomics
+              cargo-edit
+              cargo-watch
+              cargo-outdated
+              cargo-audit
+              cargo-deny
+              cargo-nextest
+              # Nix ergonomics
+              nil
+              config.treefmt.build.wrapper
+            ];
+
+            env = {
+              OPENSSL_NO_VENDOR = "1";
+              RUST_BACKTRACE = "1";
+              RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+            };
+
+            shellHook = ''
+              echo "glues dev shell - $(rustc --version)"
+            '';
+          };
+
+          # `nix flake check` runs the full matrix: workspace build, strict
+          # clippy across all targets, and the full test suite via nextest.
+          # cargo-audit / cargo-deny are left as dev-shell tools because
+          # the upstream dependency tree currently surfaces RUSTSEC
+          # advisories the flake PR shouldn't gate on - run them manually
+          # from the dev shell.
+          checks = {
+            inherit glues;
+
+            clippy = craneLib.cargoClippy (commonArgs // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--workspace --all-targets -- -D warnings";
+            });
+
+            nextest = craneLib.cargoNextest (commonArgs // {
+              inherit cargoArtifacts;
+              cargoNextestExtraArgs = "--workspace --no-fail-fast";
+              partitions = 1;
+              partitionType = "count";
+            });
+          };
+
+          # `nix fmt` formats the Nix files in this repo. Rust and TOML
+          # formatting is deliberately not wired in here because it would
+          # rewrite upstream-owned source outside this flake's scope -
+          # run `cargo fmt` / `taplo fmt` from the dev shell if desired.
+          treefmt = {
+            projectRootFile = "flake.nix";
+            programs.nixpkgs-fmt.enable = true;
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,11 @@
           # Respect the project's rust-toolchain.toml (channel 1.93, plus
           # rustfmt / clippy / llvm-tools-preview). A single source of
           # truth for the Rust version used by package, checks and shell.
-          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          # rust-src is layered on top so RUST_SRC_PATH in the dev shell
+          # actually resolves (rust-analyzer uses it for std-lib sources).
+          rustToolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+            extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
+          };
 
           craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
 
@@ -109,11 +113,11 @@
             inherit cargoArtifacts;
 
             pname = "glues";
-            # Build every workspace binary (glues, glues-tui, glues-server).
-            cargoExtraArgs = "--workspace --bins";
+            # The default install ships only the client binaries. The HTTP
+            # proxy server lives in its own package below so users who
+            # never run a remote backend don't install an unused daemon.
+            cargoExtraArgs = "--bin glues --bin glues-tui";
 
-            # Tests run in a dedicated nextest check below; `nix build`
-            # stays focused on producing the binaries.
             doCheck = false;
 
             meta = {
@@ -125,6 +129,24 @@
               platforms = lib.platforms.unix;
             };
           });
+
+          glues-server = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+
+            pname = "glues-server";
+            cargoExtraArgs = "--bin glues-server";
+
+            doCheck = false;
+
+            meta = {
+              description = "Glues HTTP proxy server";
+              homepage = workspaceCargoToml.workspace.package.repository;
+              changelog = "${workspaceCargoToml.workspace.package.repository}/releases";
+              license = lib.licenses.asl20;
+              mainProgram = "glues-server";
+              platforms = lib.platforms.unix;
+            };
+          });
         in
         {
           # Share the overlay-augmented pkgs with sibling flake-parts
@@ -133,12 +155,18 @@
 
           packages = {
             default = glues;
-            glues = glues;
+            inherit glues glues-server;
           };
 
-          apps.default = {
-            type = "app";
-            program = lib.getExe glues;
+          apps = {
+            default = {
+              type = "app";
+              program = lib.getExe glues;
+            };
+            glues-server = {
+              type = "app";
+              program = lib.getExe glues-server;
+            };
           };
 
           devShells.default = pkgs.mkShell {
@@ -157,6 +185,9 @@
               cargo-audit
               cargo-deny
               cargo-nextest
+              # Standalone TOML formatter referenced in the comments below
+              # (treefmt deliberately doesn't wire it in as a flake check).
+              taplo
               # Nix ergonomics
               nil
               config.treefmt.build.wrapper


### PR DESCRIPTION
Provides:

- `nix build`      builds glues, glues-tui and glues-server with the
workspace's pinned Rust 1.93 toolchain
- `nix develop`    dev shell with toolchain, rust-analyzer,
cargo-llvm-cov (for the AGENTS.md coverage workflow), cargo-deny,
cargo-audit and the usual cargo tooling
- `nix flake check` workspace build + strict clippy + nextest
- `nix fmt`        formats Nix files
- `overlays.default` for downstream consumers

Stack: flake-parts, crane, rust-overlay, treefmt-nix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Nix flake configuration enabling reproducible development environments, build setup, and automated code quality checks (linting, testing, formatting).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->